### PR TITLE
Enhancement: Use Travis for running a few things here and there

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: php
 
 php:
   - 5.4
+  - 5.5
+  - 5.6
 
 before_install:
   - composer self-update

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,4 +12,4 @@ install:
   - composer install
 
 script:
-  - vendor/bin/phpspec run
+  - vendor/bin/phpspec run --format=dot

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: php
+
+php:
+  - 5.4
+
+before_install:
+  - composer self-update
+
+install:
+  - composer install
+
+script:
+  - vendor/bin/phpspec run


### PR DESCRIPTION
This PR adds a very simple `.travis.yml` configuration which
    
* [x] self-updates Composer in `before_install` section
* [x] installs dependencies with Composer in `install` section
* [x] runs `phpspec` in `script` section
* [x] runs the build against PHP 5.4, 5.5, and 5.6
