### PR TITLE
Fix: Ignore directory into which coverage is generated

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+/coverage
 /vendor/
 .idea/


### PR DESCRIPTION
This PR

* [x] adds `/coverage` to `.gitignore` as this is the directory into which coverage is generated, and we don't want to commit that