### PR TITLE
Enhancement: Add Makefile with test target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,2 @@
+test:
+	vendor/bin/phpspec run


### PR DESCRIPTION
This PR

* [x] adds a `Makefile` with a `test` target, so we can save a bit of :watch: 

### Usage

Run 

```
$ make test
```