### PR TITLE
Fix: The lock file is not up to date

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "2869f1ff37fd65d52dc8a68be23c37cf",
+    "hash": "bdd3281fccb08663ccf82abf0dc10d21",
     "packages": [
         {
             "name": "league/container",


### PR DESCRIPTION
This PR

* [x] fixes an issue where `composer.lock` is not up to date