### PR TITLE
Fix: Inconsistent docblock

### DIFF
--- a/src/Hooks/Hookable.php
+++ b/src/Hooks/Hookable.php
@@ -44,7 +44,7 @@ trait Hookable
     }
 
     /**
-     * @param OperationInterface $hook
+     * @param StageInterface $hook
      * @return $this
      */
     public function addPostHook(StageInterface $hook)


### PR DESCRIPTION
This PR

* [x] updates a docblock so it matches the typehint