### PR TITLE
Fix: No need for double parentheses

### DIFF
--- a/src/Hooks/Fields.php
+++ b/src/Hooks/Fields.php
@@ -17,7 +17,7 @@ class Fields extends GetOnlyHook implements StageInterface
     {
         $fields = $request->get('fields');
 
-        if (($fields)) {
+        if ($fields) {
             $this->ensureGetOnlyRequest($request);
         }
 

--- a/src/Hooks/IncludedResource.php
+++ b/src/Hooks/IncludedResource.php
@@ -13,7 +13,7 @@ class IncludedResource extends GetOnlyHook implements StageInterface
     {
         $include = $request->get('include');
 
-        if (($include)) {
+        if ($include) {
             $this->ensureGetOnlyRequest($request);
         }
 

--- a/src/Hooks/Pagination.php
+++ b/src/Hooks/Pagination.php
@@ -14,7 +14,7 @@ class Pagination extends GetOnlyHook implements StageInterface
         $before = $request->get('before');
         $after = $request->get('after');
 
-        if (($before || $after)) {
+        if ($before || $after) {
             $this->ensureGetOnlyRequest($request);
         }
 


### PR DESCRIPTION
This PR

* [x] removes a few pairs of parentheses