### PR TITLE
Fix: Docblock for instance property and return value

### DIFF
--- a/src/Router/Routes/RouteGroup.php
+++ b/src/Router/Routes/RouteGroup.php
@@ -9,7 +9,7 @@ use Refinery29\Piston\Hooks\Hookable;
 class RouteGroup
 {
     /**
-     * @var array
+     * @var Route[]
      */
     protected $routes = [];
 
@@ -24,7 +24,7 @@ class RouteGroup
     }
 
     /**
-     * @return array
+     * @return Route[]
      */
     public function getRoutes()
     {


### PR DESCRIPTION
This PR

* [x] uses `Route[]` instead of `array` in a few docblocks, as it helps with auto-completion