### PR TITLE
Fix: Let use statement be first statement in class

### DIFF
--- a/src/Router/Routes/RouteGroup.php
+++ b/src/Router/Routes/RouteGroup.php
@@ -8,12 +8,12 @@ use Refinery29\Piston\Hooks\Hookable;
  */
 class RouteGroup
 {
+    use Hookable;
+
     /**
      * @var array
      */
     protected $routes = [];
-
-    use Hookable;
 
     /**
      * @param Route $route


### PR DESCRIPTION
This PR

* [x] moves a `use` statement importing a trait before property declarations