### PR TITLE
Fix: Reduce visibility of properties to maximum needed

### DIFF
--- a/src/Http/Request.php
+++ b/src/Http/Request.php
@@ -11,17 +11,17 @@ class Request extends SRequest
     /**
      * @var null
      */
-    protected $pagination_cursor = null;
+    private $pagination_cursor = null;
 
     /**
      * @var null
      */
-    protected $requested_fields = null;
+    private $requested_fields = null;
 
     /**
      * @var null
      */
-    protected $included_resources = null;
+    private $included_resources = null;
 
     /**
      * @return null

--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -4,7 +4,7 @@ use Symfony\Component\HttpFoundation\Response as SResponse;
 
 class Response extends SResponse
 {
-    protected $pagination;
+    private $pagination;
 
     public function setPaginationCursors(array $cursor)
     {

--- a/src/Router/RouteCollection.php
+++ b/src/Router/RouteCollection.php
@@ -19,11 +19,6 @@ class RouteCollection extends Router
     private $groups = [];
 
     /**
-     * @var Router
-     */
-    private $router;
-
-    /**
      * @param ContainerInterface $container
      */
     public function __construct(ContainerInterface $container)

--- a/src/Router/RouteCollection.php
+++ b/src/Router/RouteCollection.php
@@ -11,17 +11,17 @@ class RouteCollection extends Router
     /**
      * @var Route[]
      */
-    protected $route_objects = [];
+    private $route_objects = [];
 
     /**
      * @var RouteGroup[]
      */
-    protected $groups = [];
+    private $groups = [];
 
     /**
      * @var Router
      */
-    protected $router;
+    private $router;
 
     /**
      * @param ContainerInterface $container

--- a/src/Router/Routes/Route.php
+++ b/src/Router/Routes/Route.php
@@ -9,22 +9,22 @@ class Route
     /**
      * @var
      */
-    protected $verb;
+    private $verb;
 
     /**
      * @var
      */
-    protected $alias;
+    private $alias;
 
     /**
      * @var
      */
-    protected $action;
+    private $action;
 
     /**
      * @var bool
      */
-    protected $is_paginated = false;
+    private $is_paginated = false;
 
     /**
      * @var array

--- a/src/Router/Routes/RouteGroup.php
+++ b/src/Router/Routes/RouteGroup.php
@@ -11,7 +11,7 @@ class RouteGroup
     /**
      * @var array
      */
-    protected $routes = [];
+    private $routes = [];
 
     use Hookable;
 


### PR DESCRIPTION
This PR

* [x] reduces the visibility of instance properties from `protected` to `private`
* [x] consequently, removes an unused `private` property
