### PR TITLE
Fix: Remove else as we're returning already

### DIFF
--- a/src/Router/PistonStrategy.php
+++ b/src/Router/PistonStrategy.php
@@ -123,9 +123,9 @@ class PistonStrategy extends RequestResponseStrategy implements StrategyInterfac
                 $this->container->get($action[0]),
                 $action[1]
             ];
-        } else {
-            return $action;
         }
+
+        return $action;
     }
 
     /**


### PR DESCRIPTION
This PR

* [x] removes an unneeded `else` branch as we`re returning in the `if` branch already