### PR TITLE
Enhancement: Require PHP 5.5 or greater

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
   "name": "refinery29/piston",
   "require": {
+    "php": ">=5.5",
     "league/route": "~1.1",
     "league/pipeline": "^0.1.0",
     "nikic/fast-route": "~0.5.0"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "bdd3281fccb08663ccf82abf0dc10d21",
+    "hash": "3106a6584472d73824ba8413f2f14e5c",
     "packages": [
         {
             "name": "league/container",
@@ -1681,6 +1681,8 @@
     "stability-flags": [],
     "prefer-stable": false,
     "prefer-lowest": false,
-    "platform": [],
+    "platform": {
+        "php": ">=5.5"
+    },
     "platform-dev": []
 }


### PR DESCRIPTION
This PR

* [x] adds PHP 5.5 or greater as a platform requirement to `composer.json`

Follows https://github.com/refinery29/piston/commit/fb5855408f7e762c0e4001d857711d04c3d7cc09.
Related to https://github.com/refinery29/piston/pull/31#discussion_r33891529.