### PR TITLE
Fix: Add .editorconfig configuration for Makefile

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,3 +9,6 @@ insert_final_newline = true
 [**.php]
 indent_style = space
 indent_size = 4
+
+[Makefile]
+indent_style = tab


### PR DESCRIPTION
This PR

* [x] adds a configuration section to `.editorconfig` which overrides the `indent_style` appropriately for a `Makefile`

Follows #41.