### PR TITLE
Enhancement: Add composer target to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 composer:
 	composer install
 
-cs:
+cs: composer
 	vendor/bin/php-cs-fixer fix --config-file=.php_cs --verbose --diff
 
-test:
+test: composer
 	vendor/bin/phpspec run

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+composer:
+	composer install
+
 cs:
 	vendor/bin/php-cs-fixer fix --config-file=.php_cs --verbose --diff
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
-test:
-	vendor/bin/phpspec run
 cs:
 	vendor/bin/php-cs-fixer fix --config-file=.php_cs --verbose --diff
+
+test:
+	vendor/bin/phpspec run


### PR DESCRIPTION
This PR

* [x] sorts targets in `Makefile` alphabetically
* [x] adds a `composer` target, installing dependencies
* [x] makes `cs` and `test` targets depend on `composer` target execution

:information_desk_person: This is helpful for the extra-lazy among us, who start coding by pulling from `master` and running the tests first with 

```
$ make test
```