### PR TITLE
Fix: Only collect coverage on PHP5.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,10 @@
 language: php
 
-php:
-  - 5.5
-  - 5.6
+matrix:
+  include:
+    - php: 5.5
+    - php: 5.5
+      env: COLLECT_COVERAGE=true
 
 before_install:
   - composer self-update
@@ -15,7 +17,7 @@ script:
   - vendor/bin/phpspec run --format=dot
 
 after_script:
-  - if [[ "$TRAVIS_PULL_REQUEST" == "false" && "$TRAVIS_BRANCH" == "master" ]]; then vendor/bin/test-reporter; fi
+  - if [[ "$TRAVIS_PULL_REQUEST" == "false" && "$TRAVIS_BRANCH" == "master" && "$COLLECT_COVERAGE" == "true" ]]; then vendor/bin/test-reporter; fi
 
 addons:
   code_climate:


### PR DESCRIPTION
This PR

* [x] explicitly collects coverage on PHP5.6 only

:information_desk_person: Code Climate says that only the first payload will be accepted, so it makes sense to fix it to one build.