### PR TITLE
Refactor some Response stuff

### DIFF
--- a/spec/Hooks/Pagination/CursorBasedPaginationSpec.php
+++ b/spec/Hooks/Pagination/CursorBasedPaginationSpec.php
@@ -3,7 +3,6 @@
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Refinery29\Piston\Http\Request;
-use Refinery29\Piston\Http\Response;
 
 class CursorBasedPaginationSpec extends ObjectBehavior
 {

--- a/spec/Hooks/Pagination/OffsetLimitPaginationSpec.php
+++ b/spec/Hooks/Pagination/OffsetLimitPaginationSpec.php
@@ -3,7 +3,6 @@
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Refinery29\Piston\Http\Request;
-use Refinery29\Piston\Http\Response;
 
 class OffsetLimitPaginationSpec extends ObjectBehavior
 {

--- a/spec/Http/JsonResponseSpec.php
+++ b/spec/Http/JsonResponseSpec.php
@@ -4,12 +4,13 @@ namespace spec\Refinery29\Piston\Http;
 
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
+use Refinery29\Piston\Http\JsonResponse;
 
-class ResponseSpec extends ObjectBehavior
+class JsonResponseSpec extends ObjectBehavior
 {
     public function it_is_initializable()
     {
-        $this->shouldHaveType('Refinery29\Piston\Http\Response');
+        $this->shouldHaveType(JsonResponse::class);
     }
 
     public function it_can_get_pagination_cursors()

--- a/spec/Http/ResponseNegotiatorSpec.php
+++ b/spec/Http/ResponseNegotiatorSpec.php
@@ -5,10 +5,11 @@ namespace spec\Refinery29\Piston\Http;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Refinery29\Piston\Http\Request;
+use Refinery29\Piston\Http\ResponseNegotiator;
 use Refinery29\Piston\Stubs\FooBarResponse;
 use Symfony\Component\HttpFoundation\JsonResponse;
 
-class RequestTypeNegotiatorSpec extends ObjectBehavior
+class ResponseNegotiatorSpec extends ObjectBehavior
 {
     public function let(Request $request)
     {
@@ -18,7 +19,7 @@ class RequestTypeNegotiatorSpec extends ObjectBehavior
 
     public function it_is_initializable()
     {
-        $this->shouldHaveType('Refinery29\Piston\Http\RequestTypeNegotiator');
+        $this->shouldHaveType(ResponseNegotiator::class);
     }
 
     public function it_can_add_custom_responses()

--- a/spec/PistonSpec.php
+++ b/spec/PistonSpec.php
@@ -10,15 +10,14 @@ use Prophecy\Argument;
 use Refinery29\Piston\Decorator;
 use Refinery29\Piston\Http\JsonResponse;
 use Refinery29\Piston\Http\Request;
-use Refinery29\Piston\Http\RequestTypeNegotiator;
-use Refinery29\Piston\Http\Response;
+use Refinery29\Piston\Http\ResponseNegotiator;
 use Refinery29\Piston\Piston;
 use Refinery29\Piston\Router\Routes\Route;
 use Refinery29\Piston\Router\Routes\RouteGroup;
-use Symfony\Component\HttpFoundation\HeaderBag;
 
 class PistonSpec extends ObjectBehavior
 {
+
     public function let(Container $container)
     {
         $container->beADoubleOf('League\Container\Container');

--- a/spec/PistonSpec.php
+++ b/spec/PistonSpec.php
@@ -17,7 +17,6 @@ use Refinery29\Piston\Router\Routes\RouteGroup;
 
 class PistonSpec extends ObjectBehavior
 {
-
     public function let(Container $container)
     {
         $container->beADoubleOf('League\Container\Container');

--- a/spec/Router/PistonStrategySpec.php
+++ b/spec/Router/PistonStrategySpec.php
@@ -2,11 +2,10 @@
 
 namespace spec\Refinery29\Piston\Router;
 
-use League\Container\Container;
 use League\Container\ContainerInterface;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
-use Refinery29\Piston\Http\Response;
+use Refinery29\Piston\Http\JsonResponse as Response;
 use Refinery29\Piston\Piston;
 use Refinery29\Piston\Http\Request;
 use Kayladnls\Seesaw\RouteCollection;

--- a/spec/stubs/FooBarResponse.php
+++ b/spec/stubs/FooBarResponse.php
@@ -1,6 +1,6 @@
 <?php namespace Refinery29\Piston\Stubs;
 
-use Refinery29\Piston\Http\Response;
+use Refinery29\Piston\Http\JsonResponse as Response;
 
 class FooBarResponse extends Response
 {

--- a/src/Http/ResponseNegotiator.php
+++ b/src/Http/ResponseNegotiator.php
@@ -1,6 +1,8 @@
 <?php namespace Refinery29\Piston\Http;
 
-class RequestTypeNegotiator
+use Symfony\Component\HttpFoundation\Response;
+
+class ResponseNegotiator
 {
     protected $accept_headers;
 
@@ -13,10 +15,6 @@ class RequestTypeNegotiator
 
     public function negotiateResponse()
     {
-        if (in_array('application/json', $this->accept_headers) || empty($this->accept_headers)) {
-            return new JsonResponse();
-        }
-
         foreach ($this->accept_headers as $header) {
             if (array_key_exists($header, $this->custom_responses)) {
                 return $this->custom_responses[$header];

--- a/src/Piston.php
+++ b/src/Piston.php
@@ -14,7 +14,7 @@ use Refinery29\Piston\Hooks\Pagination\CursorBasedPagination;
 use Refinery29\Piston\Hooks\IncludedResource;
 use Refinery29\Piston\Hooks\RequestedFields;
 use Refinery29\Piston\Http\Request;
-use Refinery29\Piston\Http\RequestTypeNegotiator;
+use Refinery29\Piston\Http\ResponseNegotiator;
 use Refinery29\Piston\Router\PistonStrategy;
 use Refinery29\Piston\Router\Routes\Route;
 use Refinery29\Piston\Router\Routes\RouteGroup;
@@ -81,7 +81,7 @@ class Piston implements ContainerAwareInterface, ArrayAccess, HasHooks
 
     public function getResponse(Request $request)
     {
-        $negotiator = new RequestTypeNegotiator($request);
+        $negotiator = new ResponseNegotiator($request);
 
         return $negotiator->negotiateResponse();
     }

--- a/src/Router/HookProcessor.php
+++ b/src/Router/HookProcessor.php
@@ -2,7 +2,7 @@
 
 use Refinery29\Piston\Hooks\HasHooks;
 use Refinery29\Piston\Http\Request;
-use Refinery29\Piston\Http\Response;
+use Refinery29\Piston\Http\JsonResponse as Response;
 
 trait HookProcessor
 {


### PR DESCRIPTION
After discussion with Travis, this PR: 

- [x] Makes JSONResponse the default. 
- [x] Removes the Extended Response object, as it wasn't used
- [x] Renamed RequestTypeNegotiator to ResponseNegotiator
- [x] Moves the check for custom Responses up in the Negotiator