### PR TITLE
Enhancement: Use unified Refinery29 config for php-cs-fixer

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -1,9 +1,10 @@
 <?php
 
-$finder = Symfony\CS\Finder\DefaultFinder::create()->in(__DIR__);
+$config = new Refinery29\CS\Config\Refinery29();
+$config->getFinder()->in(__DIR__);
 
-return Symfony\CS\Config\Config::create()
-    ->setUsingCache(true)
-    ->level(Symfony\CS\FixerInterface::PSR2_LEVEL)
-    ->finder($finder)
-;
+$cacheDir = getenv('TRAVIS') ? getenv('HOME') . '/.php-cs-fixer' : __DIR__;
+
+$config->setCacheFile($cacheDir . '/.php_cs.cache');
+
+return $config;

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ matrix:
 cache:
   directories:
     - $HOME/.composer/cache
+    - $HOME/.php-cs-fixer
 
 before_install:
   - composer self-update
@@ -24,6 +25,9 @@ before_install:
 
 install:
   - composer install --prefer-dist
+
+before_script:
+  - mkdir -p "$HOME/.php-cs-fixer"
 
 script:
   - vendor/bin/php-cs-fixer fix --config-file=.php_cs --verbose --diff --dry-run

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
   },
   "require-dev": {
     "codeclimate/php-test-reporter": "^0.1.2",
-    "fabpot/php-cs-fixer": "^1.9",
+    "fabpot/php-cs-fixer": "2.0.*@dev",
     "henrikbjorn/phpspec-code-coverage": "~1.0",
     "phpspec/nyan-formatters": "~1.0",
     "phpspec/phpspec": "~2.2"

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,12 @@
 {
   "name": "refinery29/piston",
   "description": "Opinionated Micro Framework for APIs",
+  "repositories": [
+    {
+      "type": "vcs",
+      "url": "git@github.com:refinery29/php-cs-fixer-config"
+    }
+  ],
   "require": {
     "php": ">=5.5",
     "league/pipeline": "^0.1.0",
@@ -11,7 +17,8 @@
     "fabpot/php-cs-fixer": "2.0.*@dev",
     "henrikbjorn/phpspec-code-coverage": "~1.0",
     "phpspec/nyan-formatters": "~1.0",
-    "phpspec/phpspec": "~2.2"
+    "phpspec/phpspec": "~2.2",
+    "refinery29/php-cs-fixer-config": "^0.1.1"
   },
   "authors": [
     {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "973dfa3ccc9e2d86f72cf36ce08196bc",
+    "hash": "817fe1c8bad6f7d9ca784d4aad9a8ec1",
     "packages": [
         {
             "name": "kayladnls/seesaw",
@@ -420,16 +420,16 @@
         },
         {
             "name": "fabpot/php-cs-fixer",
-            "version": "v1.10",
+            "version": "dev-master",
             "source": {
                 "type": "git",
                 "url": "https://github.com/FriendsOfPHP/PHP-CS-Fixer.git",
-                "reference": "8e21b4fb32c4618a425817d9f0daf3d57a9808d1"
+                "reference": "4bc3df84dddf2629e6d96d6216f9ccae61d99389"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/zipball/8e21b4fb32c4618a425817d9f0daf3d57a9808d1",
-                "reference": "8e21b4fb32c4618a425817d9f0daf3d57a9808d1",
+                "url": "https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/zipball/4bc3df84dddf2629e6d96d6216f9ccae61d99389",
+                "reference": "4bc3df84dddf2629e6d96d6216f9ccae61d99389",
                 "shasum": ""
             },
             "require": {
@@ -450,6 +450,11 @@
                 "php-cs-fixer"
             ],
             "type": "application",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
             "autoload": {
                 "psr-4": {
                     "Symfony\\CS\\": "Symfony/CS/"
@@ -470,7 +475,7 @@
                 }
             ],
             "description": "A tool to automatically fix PHP code style",
-            "time": "2015-07-27 20:56:10"
+            "time": "2015-08-07 14:31:41"
         },
         {
             "name": "guzzle/guzzle",
@@ -2026,7 +2031,9 @@
     ],
     "aliases": [],
     "minimum-stability": "dev",
-    "stability-flags": [],
+    "stability-flags": {
+        "fabpot/php-cs-fixer": 20
+    },
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "817fe1c8bad6f7d9ca784d4aad9a8ec1",
+    "hash": "d41996a731675f098addee518ca66320",
     "packages": [
         {
             "name": "kayladnls/seesaw",
@@ -1122,6 +1122,54 @@
                 "psr-3"
             ],
             "time": "2012-12-21 11:40:51"
+        },
+        {
+            "name": "refinery29/php-cs-fixer-config",
+            "version": "0.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/refinery29/php-cs-fixer-config.git",
+                "reference": "0f86d450cf924a82cad7dd4b1d38098d3705b5bc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/refinery29/php-cs-fixer-config/zipball/0f86d450cf924a82cad7dd4b1d38098d3705b5bc",
+                "reference": "0f86d450cf924a82cad7dd4b1d38098d3705b5bc",
+                "shasum": ""
+            },
+            "require": {
+                "fabpot/php-cs-fixer": "2.0.*@dev",
+                "php": ">=5.5"
+            },
+            "require-dev": {
+                "codeclimate/php-test-reporter": "^0.1.2",
+                "phpunit/phpunit": "^4.8.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Refinery29\\CS\\Config\\": "src/"
+                }
+            },
+            "autoload-dev": {
+                "psr-4": {
+                    "Refinery29\\CS\\Config\\Test\\": "tests/"
+                }
+            },
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Andreas Möller",
+                    "email": "andreas.moller@refinery29.com"
+                }
+            ],
+            "description": "Provides a configuration for fabpot/php-cs-fixer, used within Refinery29.",
+            "support": {
+                "source": "https://github.com/refinery29/php-cs-fixer-config/tree/0.1.1"
+            },
+            "time": "2015-08-07 23:09:12"
         },
         {
             "name": "satooshi/php-coveralls",

--- a/spec/Pipeline/Stage/IncludedResourceSpec.php
+++ b/spec/Pipeline/Stage/IncludedResourceSpec.php
@@ -1,4 +1,6 @@
-<?php namespace spec\Refinery29\Piston\Pipeline\Stage;
+<?php
+
+namespace spec\Refinery29\Piston\Pipeline\Stage;
 
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;

--- a/spec/Pipeline/Stage/Pagination/CursorBasedPaginationSpec.php
+++ b/spec/Pipeline/Stage/Pagination/CursorBasedPaginationSpec.php
@@ -1,4 +1,6 @@
-<?php namespace spec\Refinery29\Piston\Pipeline\Stage\Pagination;
+<?php
+
+namespace spec\Refinery29\Piston\Pipeline\Stage\Pagination;
 
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
@@ -14,33 +16,33 @@ class CursorBasedPaginationSpec extends ObjectBehavior
 
     public function it_will_not_allow_pagination_on_non_get_requests()
     {
-        $request = Request::create('123/yolo?before=123', "PUT");
+        $request = Request::create('123/yolo?before=123', 'PUT');
 
         $this->shouldThrow('League\Route\Http\Exception\BadRequestException')->during('process', [$request]);
     }
 
     public function it_will_not_allow_before_an_after()
     {
-        $request = Request::create('123/yolo?before=123&after=456', "GET");
+        $request = Request::create('123/yolo?before=123&after=456', 'GET');
 
         $this->shouldThrow('League\Route\Http\Exception\BadRequestException')->during('process', [$request]);
     }
 
     public function it_will_allow_before_cursor_on_get_requests()
     {
-        $request = Request::create('123/yolo?before=123', "GET");
+        $request = Request::create('123/yolo?before=123', 'GET');
         $this->process($request);
     }
 
     public function it_will_allow_after_cursor_on_get_requests()
     {
-        $request = Request::create('123/yolo?after=123', "GET");
+        $request = Request::create('123/yolo?after=123', 'GET');
         $this->process($request);
     }
 
     public function it_returns_a_request()
     {
-        $request = Request::create('123/yolo?before=123', "GET");
+        $request = Request::create('123/yolo?before=123', 'GET');
         $this->process($request)->shouldReturn($request);
     }
 }

--- a/spec/Pipeline/Stage/Pagination/OffsetLimitPaginationSpec.php
+++ b/spec/Pipeline/Stage/Pagination/OffsetLimitPaginationSpec.php
@@ -1,4 +1,6 @@
-<?php namespace spec\Refinery29\Piston\Pipeline\Stage\Pagination;
+<?php
+
+namespace spec\Refinery29\Piston\Pipeline\Stage\Pagination;
 
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;

--- a/spec/Pipeline/Stage/RequestedFieldsSpec.php
+++ b/spec/Pipeline/Stage/RequestedFieldsSpec.php
@@ -1,4 +1,6 @@
-<?php namespace spec\Refinery29\Piston\Pipeline\Stage;
+<?php
+
+namespace spec\Refinery29\Piston\Pipeline\Stage;
 
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;

--- a/spec/PistonSpec.php
+++ b/spec/PistonSpec.php
@@ -1,10 +1,12 @@
-<?php namespace spec\Refinery29\Piston;
+<?php
+
+namespace spec\Refinery29\Piston;
 
 use League\Container\Container;
 use League\Container\ContainerInterface;
 use League\Container\ServiceProvider;
-use League\Pipeline\StageInterface;
 use League\Pipeline\Pipeline;
+use League\Pipeline\StageInterface;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Refinery29\Piston\Decorator;
@@ -35,18 +37,18 @@ class PistonSpec extends ObjectBehavior
 
     public function it_can_add_a_route(Route $route)
     {
-        $route->getVerb()->willReturn("GET");
+        $route->getVerb()->willReturn('GET');
         $route->getAction()->willReturn('Foo::Bar');
-        $route->getUrl()->willReturn("/yolo");
+        $route->getUrl()->willReturn('/yolo');
 
         $this->addRoute($route);
     }
 
     public function it_can_add_named_route(Route $route)
     {
-        $route->getVerb()->willReturn("GET");
+        $route->getVerb()->willReturn('GET');
         $route->getAction()->willReturn('Foo::Bar');
-        $route->getUrl()->willReturn("/yolo");
+        $route->getUrl()->willReturn('/yolo');
 
         $this->addNamedRoute('ThisIsSomeName', $route);
     }

--- a/spec/Router/PistonStrategySpec.php
+++ b/spec/Router/PistonStrategySpec.php
@@ -2,13 +2,13 @@
 
 namespace spec\Refinery29\Piston\Router;
 
+use Kayladnls\Seesaw\RouteCollection;
 use League\Container\ContainerInterface;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Refinery29\Piston\Http\JsonResponse as Response;
-use Refinery29\Piston\Piston;
 use Refinery29\Piston\Http\Request;
-use Kayladnls\Seesaw\RouteCollection;
+use Refinery29\Piston\Piston;
 use Refinery29\Piston\Router\Routes\Route;
 use Refinery29\Piston\Router\Routes\RouteGroup;
 use Refinery29\Piston\Stubs\FooController;
@@ -51,6 +51,7 @@ class PistonStrategySpec extends ObjectBehavior
         $this->dispatch(
             function ($req, $resp) {
                 $resp->setContent('YOLO');
+
                 return $resp;
             }, [])->getContent()->shouldReturn('YOLO');
     }

--- a/spec/Router/Routes/RouteGroupSpec.php
+++ b/spec/Router/Routes/RouteGroupSpec.php
@@ -2,8 +2,8 @@
 
 namespace spec\Refinery29\Piston\Router\Routes;
 
-use League\Pipeline\StageInterface;
 use League\Pipeline\Pipeline;
+use League\Pipeline\StageInterface;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Refinery29\Piston\Router\Routes\Route;

--- a/spec/Router/Routes/RouteSpec.php
+++ b/spec/Router/Routes/RouteSpec.php
@@ -1,7 +1,9 @@
-<?php namespace spec\Refinery29\Piston\Router\Routes;
+<?php
 
-use League\Pipeline\StageInterface;
+namespace spec\Refinery29\Piston\Router\Routes;
+
 use League\Pipeline\Pipeline;
+use League\Pipeline\StageInterface;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 

--- a/spec/stubs/FooBarResponse.php
+++ b/spec/stubs/FooBarResponse.php
@@ -1,4 +1,6 @@
-<?php namespace Refinery29\Piston\Stubs;
+<?php
+
+namespace Refinery29\Piston\Stubs;
 
 use Refinery29\Piston\Http\JsonResponse as Response;
 

--- a/spec/stubs/FooController.php
+++ b/spec/stubs/FooController.php
@@ -1,4 +1,6 @@
-<?php namespace Refinery29\Piston\Stubs;
+<?php
+
+namespace Refinery29\Piston\Stubs;
 
 use Refinery29\Piston\Http\Request;
 use Refinery29\Piston\Router\Routes\Routeable;
@@ -20,7 +22,7 @@ class FooController implements Routeable
     public function test($req, $resp)
     {
         if ($req->isPaginated()) {
-            echo "<pre>".print_r($req->getPaginationCursor(), true)."</pre>";
+            echo '<pre>' . print_r($req->getPaginationCursor(), true) . '</pre>';
             exit;
         }
 

--- a/src/Decorator.php
+++ b/src/Decorator.php
@@ -1,4 +1,6 @@
-<?php namespace Refinery29\Piston;
+<?php
+
+namespace Refinery29\Piston;
 
 interface Decorator
 {

--- a/src/Http/JsonResponse.php
+++ b/src/Http/JsonResponse.php
@@ -1,4 +1,6 @@
-<?php namespace Refinery29\Piston\Http;
+<?php
+
+namespace Refinery29\Piston\Http;
 
 class JsonResponse extends \Symfony\Component\HttpFoundation\JsonResponse
 {

--- a/src/Http/PaginatedResponse.php
+++ b/src/Http/PaginatedResponse.php
@@ -1,4 +1,6 @@
-<?php namespace Refinery29\Piston\Http;
+<?php
+
+namespace Refinery29\Piston\Http;
 
 trait PaginatedResponse
 {

--- a/src/Http/Pipeline/RequestPipeline.php
+++ b/src/Http/Pipeline/RequestPipeline.php
@@ -1,7 +1,9 @@
-<?php namespace Refinery29\Piston\Http\Pipeline;
+<?php
 
-use League\Pipeline\PipelineBuilder;
+namespace Refinery29\Piston\Http\Pipeline;
+
 use League\Pipeline\Pipeline;
+use League\Pipeline\PipelineBuilder;
 use Refinery29\Piston\Pipeline\Stage\IncludedResource;
 use Refinery29\Piston\Pipeline\Stage\Pagination\CursorBasedPagination;
 use Refinery29\Piston\Pipeline\Stage\Pagination\OffsetLimitPagination;

--- a/src/Http/Request.php
+++ b/src/Http/Request.php
@@ -1,10 +1,11 @@
-<?php namespace Refinery29\Piston\Http;
+<?php
+
+namespace Refinery29\Piston\Http;
 
 use Symfony\Component\HttpFoundation\Request as SRequest;
 
 /**
  * Class Request
- * @package Refinery29\Piston\Request
  */
 class Request extends SRequest
 {
@@ -34,7 +35,6 @@ class Request extends SRequest
     /** @var  var string */
     protected $after_cursor;
 
-
     /**
      * @return string
      */
@@ -44,7 +44,6 @@ class Request extends SRequest
     }
 
     /**
-     * @return null
      */
     public function getRequestedFields()
     {
@@ -60,7 +59,6 @@ class Request extends SRequest
     }
 
     /**
-     * @return null
      */
     public function getIncludedResources()
     {

--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -1,4 +1,6 @@
-<?php namespace Refinery29\Piston\Http;
+<?php
+
+namespace Refinery29\Piston\Http;
 
 use Symfony\Component\HttpFoundation\Response as SResponse;
 

--- a/src/Http/ResponseNegotiator.php
+++ b/src/Http/ResponseNegotiator.php
@@ -1,4 +1,6 @@
-<?php namespace Refinery29\Piston\Http;
+<?php
+
+namespace Refinery29\Piston\Http;
 
 use Symfony\Component\HttpFoundation\Response;
 

--- a/src/Pipeline/HasPipelines.php
+++ b/src/Pipeline/HasPipelines.php
@@ -1,4 +1,6 @@
-<?php namespace Refinery29\Piston\Pipeline;
+<?php
+
+namespace Refinery29\Piston\Pipeline;
 
 interface HasPipelines
 {

--- a/src/Pipeline/LifeCyclePipelines.php
+++ b/src/Pipeline/LifeCyclePipelines.php
@@ -1,12 +1,13 @@
-<?php namespace Refinery29\Piston\Pipeline;
+<?php
 
-use League\Pipeline\StageInterface;
+namespace Refinery29\Piston\Pipeline;
+
 use League\Pipeline\Pipeline;
 use League\Pipeline\PipelineBuilder;
+use League\Pipeline\StageInterface;
 
 /**
  * Class Hookable
- * @package Refinery29\Piston\Hooks
  */
 trait LifeCyclePipelines
 {
@@ -22,6 +23,7 @@ trait LifeCyclePipelines
 
     /**
      * @param $stage
+     *
      * @return $this
      */
     public function addPre(StageInterface $stage)
@@ -34,6 +36,7 @@ trait LifeCyclePipelines
 
     /**
      * @param StageInterface $stage
+     *
      * @return $this
      */
     public function addPost(StageInterface $stage)

--- a/src/Pipeline/PipelineProcessor.php
+++ b/src/Pipeline/PipelineProcessor.php
@@ -1,7 +1,9 @@
-<?php namespace Refinery29\Piston\Pipeline;
+<?php
 
-use Refinery29\Piston\Http\Request;
+namespace Refinery29\Piston\Pipeline;
+
 use Refinery29\Piston\Http\JsonResponse as Response;
+use Refinery29\Piston\Http\Request;
 
 trait PipelineProcessor
 {
@@ -9,11 +11,13 @@ trait PipelineProcessor
      * @param $item
      * @param $request
      * @param $original_response
+     *
      * @return Response
      */
     protected function processPrePipeline(HasPipelines $item, Request $request, Response $original_response)
     {
         $response = $item->getPrePipeline()->process([$request, $original_response]);
+
         return $response instanceof Response ? $response : $original_response;
     }
 
@@ -21,11 +25,13 @@ trait PipelineProcessor
      * @param $item
      * @param $request
      * @param $original_response
+     *
      * @return Response
      */
     protected function processPostHooks(HasPipelines $item, Request $request, Response $original_response)
     {
         $response = $item->getPostPipeline()->process([$request, $original_response]);
+
         return $response instanceof Response ? $response : $original_response;
     }
 }

--- a/src/Pipeline/Stage/GetOnlyStage.php
+++ b/src/Pipeline/Stage/GetOnlyStage.php
@@ -1,4 +1,6 @@
-<?php namespace Refinery29\Piston\Pipeline\Stage;
+<?php
+
+namespace Refinery29\Piston\Pipeline\Stage;
 
 use League\Route\Http\Exception\BadRequestException;
 
@@ -6,7 +8,7 @@ trait GetOnlyStage
 {
     public function ensureGetOnlyRequest($request)
     {
-        if ($request->getMethod() !== "GET") {
+        if ($request->getMethod() !== 'GET') {
             throw new BadRequestException('Query parameter is only allowed on GET requests');
         }
     }

--- a/src/Pipeline/Stage/IncludedResource.php
+++ b/src/Pipeline/Stage/IncludedResource.php
@@ -1,4 +1,6 @@
-<?php namespace Refinery29\Piston\Pipeline\Stage;
+<?php
+
+namespace Refinery29\Piston\Pipeline\Stage;
 
 use League\Pipeline\StageInterface;
 use Refinery29\Piston\Http\Request;
@@ -6,9 +8,10 @@ use Refinery29\Piston\Http\Request;
 class IncludedResource implements StageInterface
 {
     use GetOnlyStage;
-    
+
     /**
      * @param Request $request
+     *
      * @return Request
      */
     public function process($request)
@@ -23,7 +26,7 @@ class IncludedResource implements StageInterface
             $include = explode(',', $include);
         }
 
-        foreach ((array)$include as $k => $resource) {
+        foreach ((array) $include as $k => $resource) {
             if (strpos($resource, '.') !== false) {
                 $resource = explode('.', $resource);
 

--- a/src/Pipeline/Stage/Pagination/CursorBasedPagination.php
+++ b/src/Pipeline/Stage/Pagination/CursorBasedPagination.php
@@ -1,9 +1,11 @@
-<?php namespace Refinery29\Piston\Pipeline\Stage\Pagination;
+<?php
+
+namespace Refinery29\Piston\Pipeline\Stage\Pagination;
 
 use League\Pipeline\StageInterface;
 use League\Route\Http\Exception\BadRequestException;
-use Refinery29\Piston\Pipeline\Stage\GetOnlyStage;
 use Refinery29\Piston\Http\Request;
+use Refinery29\Piston\Pipeline\Stage\GetOnlyStage;
 
 class CursorBasedPagination implements StageInterface
 {
@@ -12,7 +14,9 @@ class CursorBasedPagination implements StageInterface
 
     /**
      * @param Request $request
+     *
      * @throws BadRequestException
+     *
      * @return Request
      */
     public function process($request)

--- a/src/Pipeline/Stage/Pagination/OffsetLimitPagination.php
+++ b/src/Pipeline/Stage/Pagination/OffsetLimitPagination.php
@@ -1,9 +1,11 @@
-<?php namespace Refinery29\Piston\Pipeline\Stage\Pagination;
+<?php
+
+namespace Refinery29\Piston\Pipeline\Stage\Pagination;
 
 use League\Pipeline\StageInterface;
 use League\Route\Http\Exception\BadRequestException;
-use Refinery29\Piston\Pipeline\Stage\GetOnlyStage;
 use Refinery29\Piston\Http\Request;
+use Refinery29\Piston\Pipeline\Stage\GetOnlyStage;
 
 class OffsetLimitPagination implements StageInterface
 {
@@ -11,18 +13,20 @@ class OffsetLimitPagination implements StageInterface
     use GetOnlyStage;
 
     /**
-     * @var int $default_offset
+     * @var int
      */
     protected $default_offset = 0;
 
     /**
-     * @var int $default_limit
+     * @var int
      */
     protected $default_limit = 10;
 
     /**
      * @param Request $request
+     *
      * @throws BadRequestException
+     *
      * @return Request
      */
     public function process($request)
@@ -44,9 +48,11 @@ class OffsetLimitPagination implements StageInterface
     }
 
     /**
-     * @param mixed $param
+     * @param mixed  $param
      * @param string $param_name
+     *
      * @throws BadRequestException
+     *
      * @return int
      */
     private function coerceToInteger($param, $param_name)

--- a/src/Pipeline/Stage/Pagination/SinglePagination.php
+++ b/src/Pipeline/Stage/Pagination/SinglePagination.php
@@ -1,4 +1,6 @@
-<?php namespace Refinery29\Piston\Pipeline\Stage\Pagination;
+<?php
+
+namespace Refinery29\Piston\Pipeline\Stage\Pagination;
 
 use League\Route\Http\Exception\BadRequestException;
 

--- a/src/Pipeline/Stage/RequestedFields.php
+++ b/src/Pipeline/Stage/RequestedFields.php
@@ -1,17 +1,19 @@
-<?php namespace Refinery29\Piston\Pipeline\Stage;
+<?php
+
+namespace Refinery29\Piston\Pipeline\Stage;
 
 use League\Pipeline\StageInterface;
 use Refinery29\Piston\Http\Request;
 
 /**
  * Class Fields
- * @package Refinery29\Piston\Request\Filters
  */
 class RequestedFields implements StageInterface
 {
     use GetOnlyStage;
     /**
      * @param Request $request
+     *
      * @return Request
      */
     public function process($request)
@@ -27,7 +29,7 @@ class RequestedFields implements StageInterface
         }
 
         if (!empty($fields)) {
-            $request->setRequestedFields((array)$fields);
+            $request->setRequestedFields((array) $fields);
         }
 
         return $request;

--- a/src/Piston.php
+++ b/src/Piston.php
@@ -1,4 +1,6 @@
-<?php namespace Refinery29\Piston;
+<?php
+
+namespace Refinery29\Piston;
 
 use ArrayAccess;
 use Kayladnls\Seesaw\Seesaw;
@@ -7,10 +9,10 @@ use League\Container\ContainerAwareInterface;
 use League\Container\ContainerInterface;
 use League\Container\ServiceProvider;
 use Refinery29\Piston\Http\Pipeline\RequestPipeline;
-use Refinery29\Piston\Pipeline\HasPipelines;
-use Refinery29\Piston\Pipeline\LifeCyclePipelines;
 use Refinery29\Piston\Http\Request;
 use Refinery29\Piston\Http\ResponseNegotiator;
+use Refinery29\Piston\Pipeline\HasPipelines;
+use Refinery29\Piston\Pipeline\LifeCyclePipelines;
 use Refinery29\Piston\Router\PistonStrategy;
 use Refinery29\Piston\Router\Routes\Route;
 use Refinery29\Piston\Router\Routes\RouteGroup;
@@ -41,10 +43,9 @@ class Piston implements ContainerAwareInterface, HasPipelines
      */
     protected $config;
 
-
     /**
      * @param ContainerInterface $container
-     * @param array $config
+     * @param array              $config
      */
     public function __construct(ContainerInterface $container = null, array $config = [])
     {
@@ -82,6 +83,7 @@ class Piston implements ContainerAwareInterface, HasPipelines
 
     /**
      * @param Route $route
+     *
      * @return Piston
      */
     public function addRoute(Route $route)
@@ -93,6 +95,7 @@ class Piston implements ContainerAwareInterface, HasPipelines
 
     /**
      * @param RouteGroup $group
+     *
      * @return $this
      */
     public function addRouteGroup(RouteGroup $group)
@@ -104,7 +107,7 @@ class Piston implements ContainerAwareInterface, HasPipelines
 
     /**
      * @param string $name
-     * @param Route $route
+     * @param Route  $route
      */
     public function addNamedRoute($name, Route $route)
     {
@@ -174,7 +177,7 @@ class Piston implements ContainerAwareInterface, HasPipelines
     private function bootstrapRouter()
     {
         $this->router = new Seesaw(null, null, $this->container);
-        $this->router->setStrategy(new PistonStrategy);
+        $this->router->setStrategy(new PistonStrategy());
         $this->container->add('PistonRouter', $this->router);
     }
 
@@ -188,6 +191,7 @@ class Piston implements ContainerAwareInterface, HasPipelines
 
     /**
      * @param $url
+     *
      * @return RedirectResponse
      */
     public static function redirect($url)

--- a/src/Router/PistonStrategy.php
+++ b/src/Router/PistonStrategy.php
@@ -1,4 +1,6 @@
-<?php namespace Refinery29\Piston\Router;
+<?php
+
+namespace Refinery29\Piston\Router;
 
 use Closure;
 use League\Route\Strategy\RequestResponseStrategy;
@@ -13,7 +15,8 @@ class PistonStrategy extends RequestResponseStrategy implements StrategyInterfac
 
     /**
      * @param array|callable|string $controller
-     * @param array $vars
+     * @param array                 $vars
+     *
      * @return mixed
      */
     public function dispatch($controller, array $vars = [])
@@ -27,7 +30,7 @@ class PistonStrategy extends RequestResponseStrategy implements StrategyInterfac
         $response = $this->processPrePipeline($app, $request, $original_response);
 
         if (is_array($controller) && is_string($controller[0])) {
-            /** @var RouteCollection */
+            /* @var RouteCollection */
             $router = $this->container->get('PistonRouter');
 
             $active_route = $router->findByAction($controller);
@@ -43,7 +46,7 @@ class PistonStrategy extends RequestResponseStrategy implements StrategyInterfac
         $response = $this->invokeAction($controller, [
             $request,
             $response,
-            $vars
+            $vars,
         ]);
 
         if (is_array($controller) && is_string($controller[0]) && isset($active_route) && !empty($active_route)) {
@@ -62,8 +65,9 @@ class PistonStrategy extends RequestResponseStrategy implements StrategyInterfac
     /**
      * Invoke a controller action
      *
-     * @param  string|\Closure $action
-     * @param  array $vars
+     * @param string|\Closure $action
+     * @param array           $vars
+     *
      * @return Response
      */
     public function invokeAction($action, array $vars = [])
@@ -78,6 +82,7 @@ class PistonStrategy extends RequestResponseStrategy implements StrategyInterfac
     /**
      * @param $action
      * @param $vars
+     *
      * @return mixed
      */
     public function dispatchRoutable($action, $vars)
@@ -91,6 +96,7 @@ class PistonStrategy extends RequestResponseStrategy implements StrategyInterfac
 
     /**
      * @param $action
+     *
      * @return array
      */
     public function resolveController($action)
@@ -98,7 +104,7 @@ class PistonStrategy extends RequestResponseStrategy implements StrategyInterfac
         if (is_array($action) && !($action[0] instanceof Routeable)) {
             return [
                 $this->container->get($action[0]),
-                $action[1]
+                $action[1],
             ];
         }
 
@@ -108,6 +114,7 @@ class PistonStrategy extends RequestResponseStrategy implements StrategyInterfac
     /**
      * @param $action
      * @param array $vars
+     *
      * @return mixed
      */
     public function dispatchClosure($action, $vars = [])
@@ -119,6 +126,7 @@ class PistonStrategy extends RequestResponseStrategy implements StrategyInterfac
 
     /**
      * @param $response
+     *
      * @return mixed
      */
     public function validateResponse($response)

--- a/src/Router/Routes/Route.php
+++ b/src/Router/Routes/Route.php
@@ -1,4 +1,6 @@
-<?php namespace Refinery29\Piston\Router\Routes;
+<?php
+
+namespace Refinery29\Piston\Router\Routes;
 
 use Kayladnls\Seesaw\Route as SeesawRoute;
 use Refinery29\Piston\Pipeline\HasPipelines;

--- a/src/Router/Routes/RouteGroup.php
+++ b/src/Router/Routes/RouteGroup.php
@@ -1,12 +1,13 @@
-<?php namespace Refinery29\Piston\Router\Routes;
+<?php
 
+namespace Refinery29\Piston\Router\Routes;
+
+use Kayladnls\Seesaw\RouteGroup as SeesawGroup;
 use Refinery29\Piston\Pipeline\HasPipelines;
 use Refinery29\Piston\Pipeline\LifeCyclePipelines;
-use Kayladnls\Seesaw\RouteGroup as SeesawGroup;
 
 /**
  * Class RouteGroup
- * @package Refinery29\Piston\Router\Routes
  */
 class RouteGroup extends SeesawGroup implements HasPipelines
 {

--- a/src/Router/Routes/Routeable.php
+++ b/src/Router/Routes/Routeable.php
@@ -1,6 +1,5 @@
 <?php
 
-
 namespace Refinery29\Piston\Router\Routes;
 
 interface Routeable


### PR DESCRIPTION
This PR

* [x] requires `fabpot/php-cs-fixer:2.0.*dev` as a development dependency
* [x] requires `refinery29/php-cs-fixer-config` as a development dependency
* [x] makes use of `Refinery29\CS\Config\Refinery29`
* [x] runs `make cs` to fix the build

Related to https://github.com/refinery29/zeppelin/pull/27.