### PR TITLE
Fix: Do not declare fields dynamically

### DIFF
--- a/spec/Pipeline/Stage/Pagination/OffsetLimitPaginationSpec.php
+++ b/spec/Pipeline/Stage/Pagination/OffsetLimitPaginationSpec.php
@@ -40,28 +40,28 @@ class OffsetLimitPaginationSpec extends ObjectBehavior
     {
         $request = $this->process(Request::create('123/yolo?limit=20&offset=40', 'GET'));
 
-        $request->limit->shouldBe(20);
+        $request->getLimit()->shouldBe(20);
     }
 
     public function it_assigns_offset_to_request_as_integer()
     {
         $request = $this->process(Request::create('123/yolo?limit=20&offset=40', 'GET'));
 
-        $request->offset->shouldBe(40);
+        $request->getOffset()->shouldBe(40);
     }
 
     public function it_assigns_default_limit_of_ten_when_none_given()
     {
         $request = $this->process(Request::create('123/yolo?offset=20', 'GET'));
 
-        $request->limit->shouldBe(10);
+        $request->getLimit()->shouldBe(10);
     }
 
     public function it_assigns_default_offset_of_zero_when_none_given()
     {
         $request = $this->process(Request::create('123/yolo?limit=20', 'GET'));
 
-        $request->offset->shouldBe(0);
+        $request->getOffset()->shouldBe(0);
     }
 
     public function it_throws_if_offset_is_not_numeric()

--- a/src/Http/Request.php
+++ b/src/Http/Request.php
@@ -136,6 +136,22 @@ class Request extends SRequest
         $this->pagination_type = 'offset_limit';
     }
 
+    /**
+     * @return int
+     */
+    public function getOffset()
+    {
+        return $this->offset;
+    }
+
+    /**
+     * @return int
+     */
+    public function getLimit()
+    {
+        return $this->limit;
+    }
+
     /** @return string */
     public function getPaginationType()
     {

--- a/src/Http/Request.php
+++ b/src/Http/Request.php
@@ -36,6 +36,16 @@ class Request extends SRequest
     protected $after_cursor;
 
     /**
+     * @var int
+     */
+    private $offset;
+
+    /**
+     * @var int
+     */
+    private $limit;
+
+    /**
      * @return string
      */
     public function getPaginationCursor()


### PR DESCRIPTION
This PR

* [x] declares `$offset` and `$limit` properties which are used, but haven't been declared before
* [x] provides accessors for `$offset` and `$limit`