### PR TITLE
Fix: Do not use is_null(), compare against null instead

### DIFF
--- a/src/Http/Request.php
+++ b/src/Http/Request.php
@@ -86,7 +86,7 @@ class Request extends SRequest
      */
     public function hasIncludedResources()
     {
-        return !is_null($this->included_resources);
+        return $this->included_resources !== null;
     }
 
     /**
@@ -94,7 +94,7 @@ class Request extends SRequest
      */
     public function hasRequestedFields()
     {
-        return !is_null($this->requested_fields);
+        return $this->requested_fields !== null;
     }
 
     /**


### PR DESCRIPTION
This PR

* [x] strictly compares against `null` instead of using `is_null()`