### PR TITLE
Fix: Docblocks which indicate that fields are of type 'var'

### DIFF
--- a/src/Http/Request.php
+++ b/src/Http/Request.php
@@ -29,10 +29,14 @@ class Request extends SRequest
      */
     protected $included_resources = null;
 
-    /** @var  var string */
+    /**
+     * @var string
+     */
     protected $before_cursor;
 
-    /** @var  var string */
+    /**
+     * @var string
+     */
     protected $after_cursor;
 
     /**


### PR DESCRIPTION
This PR

* [x] fixes docblocks which indicate that fields are of type `var`