### PR TITLE
Fix: Keep items in composer.json in order

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,25 @@
 {
   "name": "refinery29/piston",
   "description": "Opinionated Micro Framework for APIs",
+  "license": "MIT",
+  "authors": [
+    {
+      "name" : "Refinery29",
+      "email": "p.e@refinery29.com"
+    },
+    {
+      "name": "Kayla Daniels",
+      "email": "kayla.daniels@refinery29.com"
+    },
+    {
+      "name" : "Andreas Moller",
+      "email" : "andreas.moller@refinery29.com"
+    },
+    {
+      "name" : "Ryan Catlin",
+      "email" : "ryan.catlin@refinery29.com"
+    }
+  ],
   "repositories": [
     {
       "type": "vcs",
@@ -20,25 +39,6 @@
     "phpspec/phpspec": "~2.2",
     "refinery29/php-cs-fixer-config": "^0.1.1"
   },
-  "authors": [
-    {
-      "name" : "Refinery29",
-      "email": "p.e@refinery29.com"
-    },
-    {
-      "name": "Kayla Daniels",
-      "email": "kayla.daniels@refinery29.com"
-    }, 
-    {
-      "name" : "Andreas Moller",
-      "email" : "andreas.moller@refinery29.com"
-    }, 
-    {
-      "name" : "Ryan Catlin", 
-      "email" : "ryan.catlin@refinery29.com"
-    }
-  ],
-  "license": "MIT",
   "autoload": {
     "psr-4": {
       "Refinery29\\Piston\\": "src"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "535f201705e63342dba84d11c673d905",
+    "hash": "12b95636433ee433c19b3ee1f3ee62fe",
     "packages": [
         {
             "name": "kayladnls/seesaw",
@@ -157,12 +157,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/route.git",
-                "reference": "b5e3f8a6c7783faa929bc52d031066e4fb0fe2c0"
+                "reference": "079e87a4653b43e2cba47b9e0563179c1c49fcf8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/route/zipball/b5e3f8a6c7783faa929bc52d031066e4fb0fe2c0",
-                "reference": "b5e3f8a6c7783faa929bc52d031066e4fb0fe2c0",
+                "url": "https://api.github.com/repos/thephpleague/route/zipball/079e87a4653b43e2cba47b9e0563179c1c49fcf8",
+                "reference": "079e87a4653b43e2cba47b9e0563179c1c49fcf8",
                 "shasum": ""
             },
             "require": {
@@ -207,7 +207,7 @@
                 "league",
                 "route"
             ],
-            "time": "2015-09-08 08:39:47"
+            "time": "2015-09-11 07:40:31"
         },
         {
             "name": "nikic/fast-route",
@@ -429,7 +429,7 @@
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/zipball/b6b9e99d0c3b06321d2c0f1daae60d284990ffed",
+                "url": "https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/zipball/43657f29db2496462367a813359421bb11d3a197",
                 "reference": "b6b9e99d0c3b06321d2c0f1daae60d284990ffed",
                 "shasum": ""
             },
@@ -1565,12 +1565,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/Config.git",
-                "reference": "a128eea5ba356841c4a70a47b716711513b59cad"
+                "reference": "9f3a8efb74b26239972b74a93b3d31efd5789110"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Config/zipball/a128eea5ba356841c4a70a47b716711513b59cad",
-                "reference": "a128eea5ba356841c4a70a47b716711513b59cad",
+                "url": "https://api.github.com/repos/symfony/Config/zipball/9f3a8efb74b26239972b74a93b3d31efd5789110",
+                "reference": "9f3a8efb74b26239972b74a93b3d31efd5789110",
                 "shasum": ""
             },
             "require": {
@@ -1607,7 +1607,7 @@
             ],
             "description": "Symfony Config Component",
             "homepage": "https://symfony.com",
-            "time": "2015-09-03 19:46:43"
+            "time": "2015-09-09 18:22:56"
         },
         {
             "name": "symfony/console",
@@ -1615,12 +1615,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/Console.git",
-                "reference": "622cdc7c8406faa5adfe6fa45d24434f7bb72fff"
+                "reference": "c11e66c87046a1169442eb7cd55d756da4ad27af"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Console/zipball/622cdc7c8406faa5adfe6fa45d24434f7bb72fff",
-                "reference": "622cdc7c8406faa5adfe6fa45d24434f7bb72fff",
+                "url": "https://api.github.com/repos/symfony/Console/zipball/c11e66c87046a1169442eb7cd55d756da4ad27af",
+                "reference": "c11e66c87046a1169442eb7cd55d756da4ad27af",
                 "shasum": ""
             },
             "require": {
@@ -1664,7 +1664,7 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2015-09-03 11:42:45"
+            "time": "2015-09-10 08:08:06"
         },
         {
             "name": "symfony/event-dispatcher",
@@ -1672,12 +1672,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/EventDispatcher.git",
-                "reference": "8deea7a9f5560b7e70eab8d72e5e8f2d45564d15"
+                "reference": "69b6037050614d129fee27e17951ec7968f6567e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/EventDispatcher/zipball/8deea7a9f5560b7e70eab8d72e5e8f2d45564d15",
-                "reference": "8deea7a9f5560b7e70eab8d72e5e8f2d45564d15",
+                "url": "https://api.github.com/repos/symfony/EventDispatcher/zipball/69b6037050614d129fee27e17951ec7968f6567e",
+                "reference": "69b6037050614d129fee27e17951ec7968f6567e",
                 "shasum": ""
             },
             "require": {
@@ -1722,7 +1722,7 @@
             ],
             "description": "Symfony EventDispatcher Component",
             "homepage": "https://symfony.com",
-            "time": "2015-08-24 07:18:02"
+            "time": "2015-09-09 18:05:45"
         },
         {
             "name": "symfony/filesystem",
@@ -1730,12 +1730,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/Filesystem.git",
-                "reference": "b9fa06f1822de287e660130955b546777994597b"
+                "reference": "287fc0b1dcb11ff729eeefc20441c08eaf628f29"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Filesystem/zipball/b9fa06f1822de287e660130955b546777994597b",
-                "reference": "b9fa06f1822de287e660130955b546777994597b",
+                "url": "https://api.github.com/repos/symfony/Filesystem/zipball/287fc0b1dcb11ff729eeefc20441c08eaf628f29",
+                "reference": "287fc0b1dcb11ff729eeefc20441c08eaf628f29",
                 "shasum": ""
             },
             "require": {
@@ -1771,7 +1771,7 @@
             ],
             "description": "Symfony Filesystem Component",
             "homepage": "https://symfony.com",
-            "time": "2015-08-27 07:03:53"
+            "time": "2015-09-09 18:05:45"
         },
         {
             "name": "symfony/finder",


### PR DESCRIPTION
This PR

* [x] keeps items in `composer.json` in order, so that we can see the most interesting things (dependencies) at a glance