### PR TITLE
Fix: Ignore the bin dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+/bin
+!/bin/report-coverage
 /build
 /coverage
 /vendor/


### PR DESCRIPTION
This PR

* [x] adds `/bin` to `.gitignore` (excludes `/bin/report-coverage`) so that we don't end up with untracked files after installing dependencies with composer

Follows #74.