### PR TITLE
Fix: Require codeclimate/php-test-reporter:0.2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 /bin
-!/bin/report-coverage
 /build
 /coverage
 /vendor/

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,4 +34,4 @@ script:
   - bin/phpspec run --format=dot
 
 after_script:
-  - if [[ "$TRAVIS_PULL_REQUEST" == "false" && "$TRAVIS_BRANCH" == "master" && "$COLLECT_COVERAGE" == "true" ]]; then bin/report-coverage; fi
+  - if [[ "$TRAVIS_PULL_REQUEST" == "false" && "$TRAVIS_BRANCH" == "master" && "$COLLECT_COVERAGE" == "true" ]]; then bin/test-reporter; fi

--- a/bin/report-coverage
+++ b/bin/report-coverage
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-vendor/bin/test-reporter --stdout > codeclimate.json
-curl -X POST -d @codeclimate.json -H 'Content-Type: application/json' -H 'User-Agent: Code Climate (PHP Test Reporter v0.1.2)' https://codeclimate.com/test_reports

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
     "kayladnls/seesaw": "0.2.*"
   },
   "require-dev": {
-    "codeclimate/php-test-reporter": "^0.1.2",
+    "codeclimate/php-test-reporter": "0.2.0",
     "fabpot/php-cs-fixer": "2.0.*@dev",
     "henrikbjorn/phpspec-code-coverage": "~1.0",
     "phpspec/nyan-formatters": "~1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "54095f3570a0674e1d7c871f837db499",
+    "hash": "4920df12a8f1776d4ac9bfc5566aae13",
     "packages": [
         {
             "name": "kayladnls/seesaw",
@@ -309,16 +309,16 @@
     "packages-dev": [
         {
             "name": "codeclimate/php-test-reporter",
-            "version": "v0.1.2",
+            "version": "v0.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/codeclimate/php-test-reporter.git",
-                "reference": "8ed24ff30f3663ecf40f1c12d6c97eb56c69e646"
+                "reference": "85b5de950678a25f3e85adb6bc26de7f7f231d18"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/codeclimate/php-test-reporter/zipball/8ed24ff30f3663ecf40f1c12d6c97eb56c69e646",
-                "reference": "8ed24ff30f3663ecf40f1c12d6c97eb56c69e646",
+                "url": "https://api.github.com/repos/codeclimate/php-test-reporter/zipball/85b5de950678a25f3e85adb6bc26de7f7f231d18",
+                "reference": "85b5de950678a25f3e85adb6bc26de7f7f231d18",
                 "shasum": ""
             },
             "require": {
@@ -328,6 +328,7 @@
                 "symfony/console": ">=2.0"
             },
             "require-dev": {
+                "ext-xdebug": "*",
                 "phpunit/phpunit": "3.7.*@stable"
             },
             "bin": [
@@ -362,7 +363,7 @@
                 "codeclimate",
                 "coverage"
             ],
-            "time": "2014-07-23 13:42:41"
+            "time": "2015-09-08 14:22:33"
         },
         {
             "name": "doctrine/instantiator",
@@ -428,7 +429,7 @@
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/zipball/43657f29db2496462367a813359421bb11d3a197",
+                "url": "https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/zipball/ead0d6d8f714cf1b60df49800b28a76a96bd9466",
                 "reference": "43657f29db2496462367a813359421bb11d3a197",
                 "shasum": ""
             },


### PR DESCRIPTION
This PR

* [x] requires `codeclimate/php-test-reporter:0.2.0`
* [x] uses the Code Climate reporter
* [x] removes the workaround script