### PR TITLE
Fix: Run build on PHP5.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ env:
 matrix:
   include:
     - php: 5.5
-    - php: 5.5
+    - php: 5.6
       env: COLLECT_COVERAGE=true
 
 cache:


### PR DESCRIPTION
This PR

* [x] runs a build on PHP5.6 and PHP5.5, instead of running twice on PHP5.5