### PR TITLE
Fix: Update refinery29/php-cs-fixer-config

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,11 +28,11 @@
   },
   "require-dev": {
     "codeclimate/php-test-reporter": "0.2.0",
-    "fabpot/php-cs-fixer": "2.0.*@dev",
+    "fabpot/php-cs-fixer": "2.0.*-dev",
     "henrikbjorn/phpspec-code-coverage": "~1.0",
     "phpspec/nyan-formatters": "~1.0",
     "phpspec/phpspec": "~2.2",
-    "refinery29/php-cs-fixer-config": "^0.1.1"
+    "refinery29/php-cs-fixer-config": "0.2.2"
   },
   "autoload": {
     "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "d0cc430a32998b6696024f2fd2b22782",
-    "content-hash": "e6beee2a405cdcf464ce66826dd3221c",
+    "hash": "2df2ddb0cee80f81826dc30f0b75108e",
+    "content-hash": "065c1369a4594d21be20ad7b38896265",
     "packages": [
         {
             "name": "kayladnls/seesaw",
@@ -299,12 +299,12 @@
             "version": "v2.7.4",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/HttpFoundation.git",
+                "url": "https://github.com/symfony/http-foundation.git",
                 "reference": "7253c2041652353e71560bbd300d6256d170ddaf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/HttpFoundation/zipball/7253c2041652353e71560bbd300d6256d170ddaf",
+                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/7253c2041652353e71560bbd300d6256d170ddaf",
                 "reference": "7253c2041652353e71560bbd300d6256d170ddaf",
                 "shasum": ""
             },
@@ -467,12 +467,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/FriendsOfPHP/PHP-CS-Fixer.git",
-                "reference": "6fd5cb64fade985dc189e6601c20e743ac846afd"
+                "reference": "f6c3fa91e4182f197dc008862aecd24698cb2822"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/zipball/6fd5cb64fade985dc189e6601c20e743ac846afd",
-                "reference": "6fd5cb64fade985dc189e6601c20e743ac846afd",
+                "url": "https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/zipball/f6c3fa91e4182f197dc008862aecd24698cb2822",
+                "reference": "f6c3fa91e4182f197dc008862aecd24698cb2822",
                 "shasum": ""
             },
             "require": {
@@ -518,7 +518,7 @@
                 }
             ],
             "description": "A tool to automatically fix PHP code style",
-            "time": "2015-09-21 20:15:07"
+            "time": "2015-09-27 13:34:13"
         },
         {
             "name": "guzzle/guzzle",
@@ -1167,24 +1167,24 @@
         },
         {
             "name": "refinery29/php-cs-fixer-config",
-            "version": "0.1.5",
+            "version": "0.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/refinery29/php-cs-fixer-config.git",
-                "reference": "f90e5958991a568e9352119a66b7551b1177bdb0"
+                "reference": "85006570ecd1b4c9d0a8c19b934719f02c110e2d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/refinery29/php-cs-fixer-config/zipball/f90e5958991a568e9352119a66b7551b1177bdb0",
-                "reference": "f90e5958991a568e9352119a66b7551b1177bdb0",
+                "url": "https://api.github.com/repos/refinery29/php-cs-fixer-config/zipball/85006570ecd1b4c9d0a8c19b934719f02c110e2d",
+                "reference": "85006570ecd1b4c9d0a8c19b934719f02c110e2d",
                 "shasum": ""
             },
             "require": {
-                "fabpot/php-cs-fixer": "2.0.*@dev",
+                "fabpot/php-cs-fixer": "2.0.*-dev",
                 "php": ">=5.4"
             },
             "require-dev": {
-                "codeclimate/php-test-reporter": "^0.1.2",
+                "codeclimate/php-test-reporter": "0.2.0",
                 "phpunit/phpunit": "^4.8.2"
             },
             "type": "library",
@@ -1204,7 +1204,7 @@
                 }
             ],
             "description": "Provides a configuration for fabpot/php-cs-fixer, used within Refinery29.",
-            "time": "2015-09-14 12:18:40"
+            "time": "2015-09-28 12:41:00"
         },
         {
             "name": "satooshi/php-coveralls",
@@ -1599,12 +1599,12 @@
             "version": "v2.7.4",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/Config.git",
+                "url": "https://github.com/symfony/config.git",
                 "reference": "5ab9ff48b3cb5b40951a607f77fc1cbfd29edba8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Config/zipball/5ab9ff48b3cb5b40951a607f77fc1cbfd29edba8",
+                "url": "https://api.github.com/repos/symfony/config/zipball/5ab9ff48b3cb5b40951a607f77fc1cbfd29edba8",
                 "reference": "5ab9ff48b3cb5b40951a607f77fc1cbfd29edba8",
                 "shasum": ""
             },
@@ -1649,12 +1649,12 @@
             "version": "v2.7.4",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/Console.git",
+                "url": "https://github.com/symfony/console.git",
                 "reference": "9ff9032151186bd66ecee727d728f1319f52d1d8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Console/zipball/9ff9032151186bd66ecee727d728f1319f52d1d8",
+                "url": "https://api.github.com/repos/symfony/console/zipball/9ff9032151186bd66ecee727d728f1319f52d1d8",
                 "reference": "9ff9032151186bd66ecee727d728f1319f52d1d8",
                 "shasum": ""
             },
@@ -1706,12 +1706,12 @@
             "version": "v2.7.4",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/EventDispatcher.git",
+                "url": "https://github.com/symfony/event-dispatcher.git",
                 "reference": "b58c916f1db03a611b72dd702564f30ad8fe83fa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/EventDispatcher/zipball/b58c916f1db03a611b72dd702564f30ad8fe83fa",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/b58c916f1db03a611b72dd702564f30ad8fe83fa",
                 "reference": "b58c916f1db03a611b72dd702564f30ad8fe83fa",
                 "shasum": ""
             },
@@ -1764,12 +1764,12 @@
             "version": "v2.7.4",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/Filesystem.git",
+                "url": "https://github.com/symfony/filesystem.git",
                 "reference": "f079e9933799929584200b9a926f72f29e291654"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Filesystem/zipball/f079e9933799929584200b9a926f72f29e291654",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/f079e9933799929584200b9a926f72f29e291654",
                 "reference": "f079e9933799929584200b9a926f72f29e291654",
                 "shasum": ""
             },


### PR DESCRIPTION
This PR

* [x] updates `refinery29/php-cs-fixer-config`

:information_desk_person: Updating before updating dependencies and pulling in the latest changes from `fabpot/php-cs-fixer` before we have updated ours.