### PR TITLE
[Response] Instantiate ResponseBody when null

### DIFF
--- a/spec/Http/ResponseSpec.php
+++ b/spec/Http/ResponseSpec.php
@@ -13,6 +13,13 @@ class ResponseSpec extends ObjectBehavior
         $this->beConstructedWith(\Symfony\Component\HttpFoundation\Response::create(), $body);
     }
 
+    public function it_can_be_constructed_without_response_body()
+    {
+        $this->beConstructedWith(\Symfony\Component\HttpFoundation\Response::create());
+
+        $this->getContent()->shouldReturn('{}');
+    }
+
     public function it_is_initializable()
     {
         $this->shouldHaveType(Response::class);

--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -25,18 +25,10 @@ class Response implements ResponseInterface
      */
     public function __construct(SymfonyResponse $response, ResponseBody $responseBody = null)
     {
-        $this->responseBody = $responseBody;
+        $this->responseBody = $responseBody ?: new ResponseBody();
 
         $this->response = $response;
         $this->response->headers->set('Content-Type', 'application/json');
-    }
-
-    /**
-     * @param ResponseBody $responseBody
-     */
-    public function setResponseBody(ResponseBody $responseBody)
-    {
-        $this->responseBody = $responseBody;
     }
 
     public function setPagination(Pagination $pagination)

--- a/src/Http/ResponseInterface.php
+++ b/src/Http/ResponseInterface.php
@@ -5,15 +5,9 @@ namespace Refinery29\Piston\Http;
 use Refinery29\ApiOutput\Resource\Error\ErrorCollection;
 use Refinery29\ApiOutput\Resource\Pagination\Pagination;
 use Refinery29\ApiOutput\Resource\Result;
-use Refinery29\ApiOutput\ResponseBody;
 
 interface ResponseInterface
 {
-    /**
-     * @param ResponseBody $responseBody
-     */
-    public function setResponseBody(ResponseBody $responseBody);
-
     /**
      * @param Pagination $pagination
      */


### PR DESCRIPTION
### Summary
- [x] Create `ResponseBody` object if null passed into `Response` constructor
- [x] Update PHPSpec tests

### Issue
A default `ResponseBody` object is not instantiated if the `Response` is constructed with a null `ResponseBody`.

```php
use Refinery29\Piston\Http\Response;
use Symfony\Component\HttpFoundation\Response as SymfonyResponse;

$response = new Response(new SymfonyResponse());
$response->getContent(); // error
```