### PR TITLE
Fix: Add .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,10 @@
+/.phpspec           export-ignore
+/spec               export-ignore
+/.codeclimate.yml   export-ignore
+/.editorconfig      export-ignore
+/.gitattributes     export-ignore
+/.gitignore         export-ignore
+/.php_cs            export-ignore
+/.travis.yml        export-ignore
+/Makefile           export-ignore
+/phpspec.yml        export-ignore


### PR DESCRIPTION
This PR

* [x] adds a `.gitattributes` file

:information_desk_person: This prevents exporting what will likely not be needed in dependent packages.