### PR TITLE
Fix: Adding Route Groups

### DIFF
--- a/src/Piston.php
+++ b/src/Piston.php
@@ -59,11 +59,13 @@ final class Piston extends RouteCollection implements HasMiddleware
      * @param string   $prefix
      * @param callable $group
      *
-     * @return \League\Route\RouteGroup
+     * @return RouteGroup
      */
     public function group($prefix, callable $group)
     {
         $group = new RouteGroup($prefix, $group, $this);
+
+        $this->groups[] = $group;
 
         return $group;
     }


### PR DESCRIPTION
* Route Groups are not added to `Piston#$groups`
* `@return` type is more accurate as `Refinery29/Piston/Route/RouteGroup`