### PR TITLE
Only ensure GET request when include query present

### DIFF
--- a/spec/Middleware/Request/IncludedResourceSpec.php
+++ b/spec/Middleware/Request/IncludedResourceSpec.php
@@ -2,6 +2,7 @@
 
 namespace spec\Refinery29\Piston\Middleware\Request;
 
+use League\Route\Http\Exception\BadRequestException;
 use PhpSpec\ObjectBehavior;
 use Refinery29\Piston\Middleware\Payload;
 use Refinery29\Piston\Middleware\Request\IncludedResource;
@@ -47,5 +48,23 @@ class IncludedResourceSpec extends ObjectBehavior
         $resources->shouldContain(['foo',  'bing']);
         $resources->shouldContain('bar');
         $resources->shouldContain('baz');
+    }
+
+    public function it_does_not_ensure_get_only_request_when_no_resources_included(Piston $middleware)
+    {
+        $request = (new Request())->withMethod('POST');
+
+        $result = $this->process(new Payload($middleware->getWrappedObject(), $request, new Response()))->getRequest();
+
+        $result->shouldHaveType(Request::class);
+    }
+
+    public function it_ensures_get_only_request_when_resources_are_included(Piston $middleware)
+    {
+        $request = (new Request())->withMethod('POST')->withQueryParams(['include' => 'foo']);
+
+        $payload = new Payload($middleware->getWrappedObject(), $request, new Response());
+
+        $this->shouldThrow(BadRequestException::class)->duringProcess($payload);
     }
 }

--- a/src/Middleware/Request/IncludedResource.php
+++ b/src/Middleware/Request/IncludedResource.php
@@ -4,6 +4,7 @@ namespace Refinery29\Piston\Middleware\Request;
 
 use League\Pipeline\StageInterface;
 use Refinery29\Piston\Middleware\GetOnlyStage;
+use Refinery29\Piston\Middleware\Payload;
 use Refinery29\Piston\Request;
 
 class IncludedResource implements StageInterface
@@ -11,7 +12,7 @@ class IncludedResource implements StageInterface
     use GetOnlyStage;
 
     /**
-     * @param Subject $payload
+     * @param Payload $payload
      *
      * @throws \League\Route\Http\Exception\BadRequestException
      *
@@ -22,11 +23,11 @@ class IncludedResource implements StageInterface
         /** @var Request $request */
         $request = $payload->getRequest();
 
-        $this->ensureGetOnlyRequest($request);
-
         if (!isset($request->getQueryParams()['include'])) {
             return $payload;
         }
+
+        $this->ensureGetOnlyRequest($request);
 
         $include = explode(',', $request->getQueryParams()['include']);
 


### PR DESCRIPTION
### Summary
`IncludedResource#ensureGetOnlyRequest()` was called when the `include` query parameter was not present.


Thus, any non-GET requests encountered a thrown `League\Route\Http\Exception\BadRequestException`.


The Request should only be ensured that it is a GET request when the `include` query parameter is present.

### Tasks

- [x] Move call to `IncludedResource#ensureGetOnlyRequest` after check for `include` query parameter
- [x] Add spec test coverage
- [x] Extra: Fixed a typehint in `IncludedResource#process` docblock