### PR TITLE
Add Response Content-Type header with Constructor

### DIFF
--- a/spec/ResponseSpec.php
+++ b/spec/ResponseSpec.php
@@ -66,4 +66,11 @@ class ResponseSpec extends ObjectBehavior
 
         $rb->addMember($result->getSerializer())->shouldBeCalled();
     }
+
+    public function it_has_json_header(ResponseBody $rb)
+    {
+        $this->beConstructedWith($rb);
+
+        $this->getHeaderLine('content-type')->shouldReturn('application/json');
+    }
 }

--- a/src/Response.php
+++ b/src/Response.php
@@ -22,10 +22,8 @@ class Response extends DiactorosResponse
      */
     public function __construct(ResponseBody $responseBody = null, $body = 'php://memory')
     {
-        parent::__construct($body);
+        parent::__construct($body, 200, ['content-type' => 'application/json']);
         $this->responseBody = $responseBody ?: new ResponseBody();
-
-        $this->withHeader('Content-Type', 'application/json');
     }
 
     /**


### PR DESCRIPTION
`Response#withHeader` returns a new/cloned `Response` object and should not be used in a constructor.

- [x] Response did not contain `Content-Type: application/json` header.
- [x] Add header via `Response` constructor.