### PR TITLE
Allow for Other response

### DIFF
--- a/spec/ApiResponseSpec.php
+++ b/spec/ApiResponseSpec.php
@@ -11,7 +11,7 @@ use Refinery29\ApiOutput\ResponseBody;
 use Refinery29\Piston\ApiResponse;
 use Zend\Diactoros\Stream;
 
-class ResponseSpec extends ObjectBehavior
+class ApiResponseSpec extends ObjectBehavior
 {
     public function it_can_be_constructed_without_response_body(Stream $stream)
     {

--- a/spec/Middleware/PayloadSpec.php
+++ b/spec/Middleware/PayloadSpec.php
@@ -3,14 +3,14 @@
 namespace spec\Refinery29\Piston\Middleware;
 
 use PhpSpec\ObjectBehavior;
+use Refinery29\Piston\ApiResponse;
 use Refinery29\Piston\Middleware\HasMiddleware;
 use Refinery29\Piston\Middleware\Payload;
 use Refinery29\Piston\Request;
-use Refinery29\Piston\Response;
 
 class PayloadSpec extends ObjectBehavior
 {
-    public function let(HasMiddleware $subject, Request $request, Response $response)
+    public function let(HasMiddleware $subject, Request $request, ApiResponse $response)
     {
         $this->beConstructedWith($subject, $request, $response);
     }
@@ -32,6 +32,6 @@ class PayloadSpec extends ObjectBehavior
 
     public function it_can_get_response()
     {
-        $this->getResponse()->shouldHaveType(Response::class);
+        $this->getResponse()->shouldHaveType(ApiResponse::class);
     }
 }

--- a/spec/Middleware/PipelineProcessorSpec.php
+++ b/spec/Middleware/PipelineProcessorSpec.php
@@ -4,10 +4,10 @@ namespace spec\Refinery29\Piston\Middleware;
 
 use League\Pipeline\Pipeline;
 use PhpSpec\ObjectBehavior;
+use Refinery29\Piston\ApiResponse;
 use Refinery29\Piston\Middleware\Payload;
 use Refinery29\Piston\Piston;
 use Refinery29\Piston\Request;
-use Refinery29\Piston\Response;
 
 class PipelineProcessorSpec extends ObjectBehavior
 {
@@ -17,7 +17,7 @@ class PipelineProcessorSpec extends ObjectBehavior
         $middleware->getPipeline()->willReturn($pipeline);
 
         $request = new Request();
-        $response = new Response();
+        $response = new ApiResponse();
         $subject = new Payload($middleware->getWrappedObject(), $request, $response);
         $this->handlePayload($subject)->shouldHaveType(Payload::class);
     }

--- a/spec/Middleware/Request/IncludedResourceSpec.php
+++ b/spec/Middleware/Request/IncludedResourceSpec.php
@@ -4,11 +4,11 @@ namespace spec\Refinery29\Piston\Middleware\Request;
 
 use League\Route\Http\Exception\BadRequestException;
 use PhpSpec\ObjectBehavior;
+use Refinery29\Piston\ApiResponse;
 use Refinery29\Piston\Middleware\Payload;
 use Refinery29\Piston\Middleware\Request\IncludedResource;
 use Refinery29\Piston\Piston;
 use Refinery29\Piston\Request;
-use Refinery29\Piston\Response;
 
 class IncludedResourceSpec extends ObjectBehavior
 {
@@ -21,7 +21,7 @@ class IncludedResourceSpec extends ObjectBehavior
     {
         /** @var Request $request */
         $request = (new Request())->withQueryParams(['include' => 'foo,bar,baz']);
-        $result = $this->process(new Payload($middleware->getWrappedObject(), $request, new Response()))->getRequest();
+        $result = $this->process(new Payload($middleware->getWrappedObject(), $request, new ApiResponse()))->getRequest();
 
         $result->shouldHaveType(Request::class);
 
@@ -38,7 +38,7 @@ class IncludedResourceSpec extends ObjectBehavior
         /** @var Request $request */
         $request = (new Request())->withQueryParams(['include' => 'foo.bing,bar,baz']);
 
-        $result = $this->process(new Payload($middleware->getWrappedObject(), $request, new Response()))->getRequest();
+        $result = $this->process(new Payload($middleware->getWrappedObject(), $request, new ApiResponse()))->getRequest();
 
         $result->shouldHaveType(Request::class);
 
@@ -54,7 +54,7 @@ class IncludedResourceSpec extends ObjectBehavior
     {
         $request = (new Request())->withMethod('POST');
 
-        $result = $this->process(new Payload($middleware->getWrappedObject(), $request, new Response()))->getRequest();
+        $result = $this->process(new Payload($middleware->getWrappedObject(), $request, new ApiResponse()))->getRequest();
 
         $result->shouldHaveType(Request::class);
     }
@@ -63,7 +63,7 @@ class IncludedResourceSpec extends ObjectBehavior
     {
         $request = (new Request())->withMethod('POST')->withQueryParams(['include' => 'foo']);
 
-        $payload = new Payload($middleware->getWrappedObject(), $request, new Response());
+        $payload = new Payload($middleware->getWrappedObject(), $request, new ApiResponse());
 
         $this->shouldThrow(BadRequestException::class)->duringProcess($payload);
     }

--- a/spec/Middleware/Request/Pagination/CursorBasedPaginationSpec.php
+++ b/spec/Middleware/Request/Pagination/CursorBasedPaginationSpec.php
@@ -4,11 +4,11 @@ namespace spec\Refinery29\Piston\Middleware\Request\Pagination;
 
 use League\Route\Http\Exception\BadRequestException;
 use PhpSpec\ObjectBehavior;
+use Refinery29\Piston\ApiResponse;
 use Refinery29\Piston\Middleware\Payload;
 use Refinery29\Piston\Middleware\Request\Pagination\CursorBasedPagination;
 use Refinery29\Piston\Piston;
 use Refinery29\Piston\RequestFactory;
-use Refinery29\Piston\Response;
 
 class CursorBasedPaginationSpec extends ObjectBehavior
 {
@@ -66,6 +66,6 @@ class CursorBasedPaginationSpec extends ObjectBehavior
 
     private function getPayload($request, Piston $middleware)
     {
-        return new Payload($middleware->getWrappedObject(), $request, new Response());
+        return new Payload($middleware->getWrappedObject(), $request, new ApiResponse());
     }
 }

--- a/spec/Middleware/Request/Pagination/OffsetLimitPaginationSpec.php
+++ b/spec/Middleware/Request/Pagination/OffsetLimitPaginationSpec.php
@@ -4,11 +4,11 @@ namespace spec\Refinery29\Piston\Middleware\Request\Pagination;
 
 use League\Route\Http\Exception\BadRequestException;
 use PhpSpec\ObjectBehavior;
+use Refinery29\Piston\ApiResponse;
 use Refinery29\Piston\Middleware\Payload;
 use Refinery29\Piston\Middleware\Request\Pagination\OffsetLimitPagination;
 use Refinery29\Piston\Piston;
 use Refinery29\Piston\RequestFactory;
-use Refinery29\Piston\Response;
 
 class OffsetLimitPaginationSpec extends ObjectBehavior
 {
@@ -110,6 +110,6 @@ class OffsetLimitPaginationSpec extends ObjectBehavior
 
     private function getPayload($request, Piston $piston)
     {
-        return new Payload($piston->getWrappedObject(), $request, new Response());
+        return new Payload($piston->getWrappedObject(), $request, new ApiResponse());
     }
 }

--- a/spec/Middleware/Request/RequestPipelineSpec.php
+++ b/spec/Middleware/Request/RequestPipelineSpec.php
@@ -3,11 +3,11 @@
 namespace spec\Refinery29\Piston\Middleware\Request;
 
 use PhpSpec\ObjectBehavior;
+use Refinery29\Piston\ApiResponse;
 use Refinery29\Piston\Middleware\Payload;
 use Refinery29\Piston\Middleware\Request\RequestPipeline;
 use Refinery29\Piston\Piston;
 use Refinery29\Piston\Request;
-use Refinery29\Piston\Response;
 
 class RequestPipelineSpec extends ObjectBehavior
 {
@@ -19,7 +19,7 @@ class RequestPipelineSpec extends ObjectBehavior
     public function it_can_be_processed(Piston $middleware)
     {
         $request = new Request();
-        $response = new Response();
+        $response = new ApiResponse();
         $subject = new Payload($middleware->getWrappedObject(), $request, $response);
 
         $this->process($subject)->shouldHaveType(Payload::class);

--- a/spec/Middleware/Request/RequestedFieldsSpec.php
+++ b/spec/Middleware/Request/RequestedFieldsSpec.php
@@ -3,11 +3,11 @@
 namespace spec\Refinery29\Piston\Middleware\Request;
 
 use PhpSpec\ObjectBehavior;
+use Refinery29\Piston\ApiResponse;
 use Refinery29\Piston\Middleware\Payload;
 use Refinery29\Piston\Middleware\Request\RequestedFields;
 use Refinery29\Piston\Piston;
 use Refinery29\Piston\Request;
-use Refinery29\Piston\Response;
 
 class RequestedFieldsSpec extends ObjectBehavior
 {
@@ -20,7 +20,7 @@ class RequestedFieldsSpec extends ObjectBehavior
     {
         $request = (new Request())->withQueryParams(['fields' => 'one,two,three']);
 
-        $subject = new Payload($middleware->getWrappedObject(), $request, new Response());
+        $subject = new Payload($middleware->getWrappedObject(), $request, new ApiResponse());
 
         $result = $this->process($subject);
         $result = $result->getRequest();

--- a/spec/PistonSpec.php
+++ b/spec/PistonSpec.php
@@ -8,11 +8,11 @@ use League\Pipeline\CallableStage;
 use League\Pipeline\StageInterface;
 use League\Route\Http\Exception\NotFoundException;
 use PhpSpec\ObjectBehavior;
+use Refinery29\Piston\ApiResponse;
 use Refinery29\Piston\Middleware\ExceptionalPipeline;
 use Refinery29\Piston\Piston;
 use Refinery29\Piston\Request;
 use Refinery29\Piston\RequestFactory;
-use Refinery29\Piston\Response;
 use Refinery29\Piston\Router\RouteGroup;
 use Refinery29\Piston\Stubs\FooController;
 use Refinery29\Piston\Stubs\ReturnEmitter;
@@ -151,7 +151,7 @@ class PistonSpec extends ObjectBehavior
         $emitter = new ReturnEmitter();
         $this->beConstructedWith(null, null, $emitter);
         $response = $this->launch();
-        $response->shouldHaveType(Response::class);
+        $response->shouldHaveType(ApiResponse::class);
 
         $response->getStatusCode()->shouldReturn(404);
     }
@@ -170,7 +170,7 @@ class PistonSpec extends ObjectBehavior
         });
 
         $response = $this->launch()->getWrappedObject();
-        $response->shouldHaveType(Response::class);
+        $response->shouldHaveType(ApiResponse::class);
 
         $response->getStatusCode()->shouldReturn(300);
     }
@@ -189,7 +189,7 @@ class PistonSpec extends ObjectBehavior
         });
 
         $response = $this->launch()->getWrappedObject();
-        $response->shouldHaveType(Response::class);
+        $response->shouldHaveType(ApiResponse::class);
 
         $response->getBody()->__toString()->shouldReturn("I'm blue da ba dee");
     }
@@ -208,7 +208,7 @@ class PistonSpec extends ObjectBehavior
         $emitter = new ReturnEmitter();
         $this->beConstructedWith(null, null, $emitter);
         $response = $this->launch();
-        $response->shouldHaveType(Response::class);
+        $response->shouldHaveType(ApiResponse::class);
 
         $response->getStatusCode()->shouldReturn(404);
 

--- a/spec/PistonSpec.php
+++ b/spec/PistonSpec.php
@@ -143,7 +143,7 @@ class PistonSpec extends ObjectBehavior
             $router->get('/something', FooController::class . '::testHTMLResponse')->setName('something');
         });
 
-        $this->launch()->shouldReturn('<p>Hello Worldmake cs</p>');
+        $this->launch()->shouldReturn('<p>Hello World</p>');
     }
 
     public function it_can_register_and_catch_exceptions()

--- a/spec/PistonSpec.php
+++ b/spec/PistonSpec.php
@@ -143,10 +143,8 @@ class PistonSpec extends ObjectBehavior
             $router->get('/something', FooController::class . '::testHTMLResponse')->setName('something');
         });
 
-        $this->launch()->shouldReturn('<p>Hello World</p>');
+        $this->launch()->shouldReturn('<p>Hello Worldmake cs</p>');
     }
-
-
 
     public function it_can_register_and_catch_exceptions()
     {

--- a/spec/PistonSpec.php
+++ b/spec/PistonSpec.php
@@ -133,6 +133,21 @@ class PistonSpec extends ObjectBehavior
         $this->launch()->shouldReturn('{"result":{"something":"yolo"}}');
     }
 
+    public function it_can_launch_non_compiled_responses()
+    {
+        $request = RequestFactory::fromGlobals()->withUri(new Uri('/prefix/something'));
+        $emitter = new StringEmitter();
+
+        $this->beConstructedWith(null, $request, $emitter);
+        $this->group('/prefix', function (RouteGroup $router) {
+            $router->get('/something', FooController::class . '::testHTMLResponse')->setName('something');
+        });
+
+        $this->launch()->shouldReturn('<p>Hello World</p>');
+    }
+
+
+
     public function it_can_register_and_catch_exceptions()
     {
         $this->addMiddleware(CallableStage::forCallable(function () {

--- a/spec/ResponseSpec.php
+++ b/spec/ResponseSpec.php
@@ -8,7 +8,7 @@ use Refinery29\ApiOutput\Resource\Error\ErrorCollection as ErrorCollectionResour
 use Refinery29\ApiOutput\Resource\Pagination\Pagination;
 use Refinery29\ApiOutput\Resource\Result;
 use Refinery29\ApiOutput\ResponseBody;
-use Refinery29\Piston\Response;
+use Refinery29\Piston\ApiResponse;
 use Zend\Diactoros\Stream;
 
 class ResponseSpec extends ObjectBehavior
@@ -25,12 +25,12 @@ class ResponseSpec extends ObjectBehavior
 
     public function it_is_initializable()
     {
-        $this->shouldHaveType(Response::class);
+        $this->shouldHaveType(ApiResponse::class);
     }
 
     public function it_can_set_status_code()
     {
-        $this->setStatusCode('200')->shouldHaveType(Response::class);
+        $this->setStatusCode('200')->shouldHaveType(ApiResponse::class);
         $this->setStatusCode('400')->getStatusCode()->shouldReturn(400);
     }
 

--- a/spec/Router/MiddlewareStrategySpec.php
+++ b/spec/Router/MiddlewareStrategySpec.php
@@ -5,9 +5,9 @@ namespace spec\Refinery29\Piston\Router;
 use League\Container\ContainerInterface;
 use League\Pipeline\Pipeline;
 use PhpSpec\ObjectBehavior;
+use Refinery29\Piston\ApiResponse;
 use Refinery29\Piston\Request;
 use Refinery29\Piston\RequestFactory;
-use Refinery29\Piston\Response;
 use Refinery29\Piston\Router\MiddlewareStrategy;
 use Refinery29\Piston\Router\Route;
 use Refinery29\Piston\Router\RouteGroup;
@@ -18,7 +18,7 @@ class MiddlewareStrategySpec extends ObjectBehavior
     public function let(ContainerInterface $container)
     {
         $container->get('Request')->willReturn(RequestFactory::createFromUri('/alias'));
-        $container->get('Response')->willReturn(new Response());
+        $container->get('Response')->willReturn(new ApiResponse());
         $container->get('Refinery29\Piston\Stubs\FooController')->willReturn(new FooController());
     }
 
@@ -27,7 +27,7 @@ class MiddlewareStrategySpec extends ObjectBehavior
         $this->shouldHaveType(MiddlewareStrategy::class);
     }
 
-    public function it_can_dispatch_controller(Route $route, FooController $foo, Request $request, Response $response)
+    public function it_can_dispatch_controller(Route $route, FooController $foo, Request $request, ApiResponse $response)
     {
         $route->getParentGroup()->willReturn(false);
         $route->getPipeline()->willReturn(new Pipeline());
@@ -37,10 +37,10 @@ class MiddlewareStrategySpec extends ObjectBehavior
             ->setRequest($request);
 
         $this->dispatch(
-            [$foo, 'test'], [], $route)->shouldHaveType(Response::class);
+            [$foo, 'test'], [], $route)->shouldHaveType(ApiResponse::class);
     }
 
-    public function it_handles_group_middleware(RouteGroup $group, Route $route, FooController $foo, Request $request, Response $response)
+    public function it_handles_group_middleware(RouteGroup $group, Route $route, FooController $foo, Request $request, ApiResponse $response)
     {
         $route->getParentGroup()->willReturn($group);
         $route->getPipeline()->willReturn(new Pipeline());
@@ -58,7 +58,7 @@ class MiddlewareStrategySpec extends ObjectBehavior
             [$foo, 'test'], [], $route);
     }
 
-    public function it_handles_route_middleware(Route $route, FooController $foo, Request $request, Response $response)
+    public function it_handles_route_middleware(Route $route, FooController $foo, Request $request, ApiResponse $response)
     {
         $route->getParentGroup()->willReturn(false);
         $route->getPipeline()->willReturn(new Pipeline());

--- a/spec/stubs/FooController.php
+++ b/spec/stubs/FooController.php
@@ -3,8 +3,8 @@
 namespace Refinery29\Piston\Stubs;
 
 use Refinery29\ApiOutput\Resource\ResourceFactory;
+use Refinery29\Piston\ApiResponse;
 use Refinery29\Piston\Request;
-use Refinery29\Piston\Response;
 
 /**
  * Created by PhpStorm.
@@ -14,12 +14,12 @@ use Refinery29\Piston\Response;
  */
 class FooController
 {
-    public function fooAction(Request $req, Response $resp)
+    public function fooAction(Request $req, ApiResponse $resp)
     {
         return $resp;
     }
 
-    public function test(Request $req, Response $response)
+    public function test(Request $req, ApiResponse $response)
     {
         $response->setResult(ResourceFactory::result(['something' => 'yolo']));
 

--- a/spec/stubs/FooController.php
+++ b/spec/stubs/FooController.php
@@ -5,6 +5,7 @@ namespace Refinery29\Piston\Stubs;
 use Refinery29\ApiOutput\Resource\ResourceFactory;
 use Refinery29\Piston\ApiResponse;
 use Refinery29\Piston\Request;
+use Zend\Diactoros\Response\HtmlResponse;
 
 /**
  * Created by PhpStorm.
@@ -24,5 +25,10 @@ class FooController
         $response->setResult(ResourceFactory::result(['something' => 'yolo']));
 
         return $response;
+    }
+
+    public function testHTMLResponse()
+    {
+        return new HTMLResponse('<p>Hello World</p>');
     }
 }

--- a/src/ApiResponse.php
+++ b/src/ApiResponse.php
@@ -9,7 +9,7 @@ use Refinery29\ApiOutput\Resource\Result;
 use Refinery29\ApiOutput\ResponseBody;
 use Zend\Diactoros\Response as DiactorosResponse;
 
-class Response extends DiactorosResponse
+class ApiResponse extends DiactorosResponse implements CompiledResponse
 {
     /**
      * @var ResponseBody
@@ -53,7 +53,7 @@ class Response extends DiactorosResponse
     /**
      * @param int $code
      *
-     * @return Response
+     * @return ApiResponse
      */
     public function setStatusCode($code)
     {

--- a/src/CompiledResponse.php
+++ b/src/CompiledResponse.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Refinery29\Piston;
+
+interface CompiledResponse
+{
+    public function compileContent();
+}

--- a/src/Middleware/Payload.php
+++ b/src/Middleware/Payload.php
@@ -2,8 +2,8 @@
 
 namespace Refinery29\Piston\Middleware;
 
+use Refinery29\Piston\ApiResponse;
 use Refinery29\Piston\Request;
-use Refinery29\Piston\Response;
 
 class Payload
 {
@@ -18,11 +18,11 @@ class Payload
     private $request;
 
     /**
-     * @var Response
+     * @var ApiResponse
      */
     private $response;
 
-    public function __construct(HasMiddleware $subject, Request $request, Response $response)
+    public function __construct(HasMiddleware $subject, Request $request, ApiResponse $response)
     {
         $this->subject = $subject;
         $this->request = $request;
@@ -46,7 +46,7 @@ class Payload
     }
 
     /**
-     * @return Response
+     * @return ApiResponse
      */
     public function getResponse()
     {

--- a/src/Piston.php
+++ b/src/Piston.php
@@ -24,7 +24,7 @@ class Piston extends RouteCollection implements Middleware\HasMiddleware
     private $request = null;
 
     /**
-     * @var Response
+     * @var ApiResponse
      */
     private $response;
 
@@ -52,7 +52,7 @@ class Piston extends RouteCollection implements Middleware\HasMiddleware
         $this->request = $request ?: RequestFactory::fromGlobals();
         $this->emitter = $emitter ?: new SapiEmitter();
 
-        $this->response = new Response();
+        $this->response = new ApiResponse();
 
         $this->loadContainer();
         parent::__construct($this->container);
@@ -106,7 +106,7 @@ class Piston extends RouteCollection implements Middleware\HasMiddleware
     /**
      * @throws \Exception
      *
-     * @return Response
+     * @return ApiResponse
      */
     public function launch()
     {
@@ -114,7 +114,10 @@ class Piston extends RouteCollection implements Middleware\HasMiddleware
             $this->processPipeline();
 
             $this->response = $this->dispatch($this->request, $this->response);
-            $this->response->compileContent();
+
+            if ($this->response instanceof CompiledResponse) {
+                $this->response->compileContent();
+            }
 
             return $this->emitter->emit($this->response);
         } catch (\Exception $e) {
@@ -173,7 +176,7 @@ class Piston extends RouteCollection implements Middleware\HasMiddleware
         (new Middleware\Request\RequestPipeline())->process($this->buildPayload());
 
         $this->container->add(Request::class, $this->request, true);
-        $this->container->add(Response::class, $this->response, true);
+        $this->container->add(ApiResponse::class, $this->response, true);
     }
 
     /**

--- a/src/Router/MiddlewareStrategy.php
+++ b/src/Router/MiddlewareStrategy.php
@@ -5,9 +5,9 @@ namespace Refinery29\Piston\Router;
 use League\Route\Route;
 use League\Route\Strategy\RequestResponseStrategy;
 use League\Route\Strategy\StrategyInterface;
+use Refinery29\Piston\ApiResponse;
 use Refinery29\Piston\Middleware\Payload;
 use Refinery29\Piston\Middleware\PipelineProcessor;
-use Refinery29\Piston\Response;
 
 class MiddlewareStrategy extends RequestResponseStrategy implements StrategyInterface
 {
@@ -18,7 +18,7 @@ class MiddlewareStrategy extends RequestResponseStrategy implements StrategyInte
      *
      * @throws \Exception
      *
-     * @return Response
+     * @return ApiResponse
      */
     public function dispatch(callable $controller, array $vars = [], Route $route = null)
     {


### PR DESCRIPTION
This PR: 
- [x] Created CompiledResponse interface
- [x] Renames `Piston/Response` to `Piston/ApiResponse`, better describing what it is. 

Currently Piston only allows for a `Piston\Response` to be used and returned. Anything else will result in an error. This PR makes it so that only compiled responses are compiled and any other response is allowed to continue on as normal. This will allow for `HTMLResponse` to be used, or even an XMLResponse or any custom Response object