### PR TITLE
Sort Request Stage

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,4 +204,18 @@ array
 ```
 
 
+### Sorting
+
+Sort parameters are provided on the request as a `sort` query parameter:
+
+`url.com?sort=-created,title`
+
+The sort query parameter should be a comma delimited list of sort attributes.
+
+Sort order is defined by negating the sort attribute with a minus sign as it's prefix (e.g. `-created` is negated while `created` is not negated). If the sort attribute is negated then the sort direction will be `'DESC'` (descending), otherwise `'ASC'` (ascending) is used.
+
+Sort values can be checked by calling `Request#getSort($name)` which will return either `'ASC'` or `'DESC'`.
+
+
+
 All of the above filters are only allowed on `GET` requests. Use of any of these parameters will result in an error if used with any other HTTP verb.

--- a/spec/Middleware/Request/SortsSpec.php
+++ b/spec/Middleware/Request/SortsSpec.php
@@ -1,0 +1,106 @@
+<?php
+
+/*
+ * Copyright (c) 2016 Refinery29, Inc.
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace spec\Refinery29\Piston\Middleware\Request;
+
+use League\Route\Http\Exception\BadRequestException;
+use PhpSpec\ObjectBehavior;
+use Refinery29\Piston\ApiResponse;
+use Refinery29\Piston\Middleware\Payload;
+use Refinery29\Piston\Middleware\Request\Sorts;
+use Refinery29\Piston\Piston;
+use Refinery29\Piston\Request;
+
+class SortsSpec extends ObjectBehavior
+{
+    public function it_is_initializable()
+    {
+        $this->shouldHaveType(Sorts::class);
+    }
+
+    public function it_will_get_sort(Piston $middleware)
+    {
+        /** @var Request $request */
+        $request = (new Request())->withQueryParams([
+            'sort' => implode(',', [
+                '-created',
+                'title',
+            ]),
+        ]);
+
+        $result = $this->process(new Payload($middleware->getWrappedObject(), $request, new ApiResponse()))->getRequest();
+
+        $result->shouldHaveType(Request::class);
+
+        $result->getSort('created')->shouldBe(Sorts::SORT_DESCENDING);
+        $result->getSort('title')->shouldBe(Sorts::SORT_ASCENDING);
+        $result->getSort('not-set')->shouldBe(null);
+    }
+
+    public function it_does_not_throw_exception_with_no_sort(Piston $middleware)
+    {
+        $result = $this->process(new Payload(
+            $middleware->getWrappedObject(),
+            new Request(),
+            new ApiResponse()
+        ))->getRequest();
+
+        $result->shouldHaveType(Request::class);
+    }
+
+    public function it_throws_exception_on_empty_sort_string(Piston $middleware)
+    {
+        /** @var Request $request */
+        $request = (new Request())->withMethod('GET')->withQueryParams(['sort' => '']);
+
+        $payload = new Payload($middleware->getWrappedObject(), $request, new ApiResponse());
+
+        $this->shouldThrow(BadRequestException::class)->duringProcess($payload);
+    }
+
+    public function it_throws_exception_on_empty_descending_sort(Piston $middleware)
+    {
+        /** @var Request $request */
+        $request = (new Request())->withMethod('GET')->withQueryParams(['sort' => '-']);
+
+        $payload = new Payload($middleware->getWrappedObject(), $request, new ApiResponse());
+
+        $this->shouldThrow(BadRequestException::class)->duringProcess($payload);
+    }
+
+    public function it_throws_exception_on_empty_sort_name_with_valid_sort_name(Piston $middleware)
+    {
+        /** @var Request $request */
+        $request = (new Request())->withMethod('GET')->withQueryParams(['sort' => 'foo,']);
+
+        $payload = new Payload($middleware->getWrappedObject(), $request, new ApiResponse());
+
+        $this->shouldThrow(BadRequestException::class)->duringProcess($payload);
+    }
+
+    public function it_does_not_ensure_get_only_request_when_no_sorts_are_included(Piston $middleware)
+    {
+        /** @var Request $request */
+        $request = (new Request())->withMethod('PATCH');
+
+        $result = $this->process(new Payload($middleware->getWrappedObject(), $request, new ApiResponse()))->getRequest();
+
+        $result->shouldHaveType(Request::class);
+    }
+
+    public function it_ensures_get_only_request_when_sorts_are_included(Piston $middleware)
+    {
+        /** @var Request $request */
+        $request = (new Request())->withMethod('PUT')->withQueryParams(['sort' => '-foo']);
+
+        $payload = new Payload($middleware->getWrappedObject(), $request, new ApiResponse());
+
+        $this->shouldThrow(BadRequestException::class)->duringProcess($payload);
+    }
+}

--- a/src/Middleware/Request/RequestPipeline.php
+++ b/src/Middleware/Request/RequestPipeline.php
@@ -47,7 +47,8 @@ class RequestPipeline implements StageInterface
             ->add(new IncludedResource())
             ->add(new RequestedFields())
             ->add(new OffsetLimitPagination())
-            ->add(new CursorBasedPagination());
+            ->add(new CursorBasedPagination())
+            ->add(new Sorts());
 
         $this->pipeline = $this->builder->build();
 

--- a/src/Middleware/Request/Sorts.php
+++ b/src/Middleware/Request/Sorts.php
@@ -1,0 +1,68 @@
+<?php
+
+/*
+ * Copyright (c) 2016 Refinery29, Inc.
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Refinery29\Piston\Middleware\Request;
+
+use League\Pipeline\StageInterface;
+use League\Route\Http\Exception\BadRequestException;
+use Refinery29\Piston\Middleware\GetOnlyStage;
+use Refinery29\Piston\Middleware\Payload;
+use Refinery29\Piston\Request;
+
+class Sorts implements StageInterface
+{
+    use GetOnlyStage;
+
+    const SORT_ASCENDING = 'ASC';
+    const SORT_DESCENDING = 'DESC';
+
+    /**
+     * @param Payload $payload
+     *
+     * @throws \League\Route\Http\Exception\BadRequestException
+     *
+     * @return Request
+     */
+    public function process($payload)
+    {
+        /** @var Request $request */
+        $request = $payload->getRequest();
+
+        if (!isset($request->getQueryParams()['sort'])) {
+            return $payload;
+        }
+
+        $this->ensureGetOnlyRequest($request);
+
+        $providedSorts = explode(',', $request->getQueryParams()['sort']);
+
+        if (empty($providedSorts)) {
+            return $payload;
+        }
+
+        $sorts = [];
+
+        foreach ($providedSorts as $sort) {
+            if (strlen($sort) <= 0 || $sort === '-') {
+                throw new BadRequestException('Sort parameter cannot be empty.');
+            }
+
+            if ($sort[0] === '-') {
+                $sorts[substr($sort, 1)] = self::SORT_DESCENDING;
+                continue;
+            }
+
+            $sorts[$sort] = self::SORT_ASCENDING;
+        }
+
+        $request->setSorts($sorts);
+
+        return $payload;
+    }
+}

--- a/src/Request.php
+++ b/src/Request.php
@@ -88,6 +88,11 @@ class Request extends ServerRequest
     private $cookieJar;
 
     /**
+     * @var array
+     */
+    private $sorts = null;
+
+    /**
      * @return string
      */
     public function getPaginationCursor()
@@ -225,5 +230,41 @@ class Request extends ServerRequest
         $this->cookieJar->clearAll();
 
         return $this->withCookieParams($this->cookieJar->all());
+    }
+
+    /**
+     * @param array $sorts
+     */
+    public function setSorts(array $sorts)
+    {
+        $this->sorts = $sorts;
+    }
+
+    /**
+     * @param string $name
+     *
+     * @return bool
+     */
+    public function hasSort($name)
+    {
+        if ($this->sorts === null) {
+            return false;
+        }
+
+        return array_key_exists($name, $this->sorts);
+    }
+
+    /**
+     * @param string $name
+     *
+     * @return string
+     */
+    public function getSort($name)
+    {
+        if (!$this->hasSort($name)) {
+            return;
+        }
+
+        return $this->sorts[$name];
     }
 }


### PR DESCRIPTION
* New `Sorts` Request stage
* Parse `sort` query parameter into an associative array of `[columnToSort => 'ASC'|'DESC]`
* Adheres to Sort API Standard https://github.com/refinery29/api-standards#sorting