### PR TITLE
Fix: Update refinery29/php-cs-fixer-config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ before_script:
   - mkdir -p "$HOME/.php-cs-fixer"
 
 script:
-  - bin/php-cs-fixer fix --config-file=.php_cs --verbose --diff --dry-run
+  - bin/php-cs-fixer fix --config=.php_cs --verbose --diff --dry-run
   - bin/phpspec run --format=dot
 
 after_script:

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ composer:
 	composer install
 
 cs: composer
-	bin/php-cs-fixer fix --config-file=.php_cs --verbose --diff
+	bin/php-cs-fixer fix --config=.php_cs --verbose --diff
 
 test: composer
 	bin/phpspec run

--- a/composer.json
+++ b/composer.json
@@ -29,11 +29,10 @@
   },
   "require-dev": {
     "codeclimate/php-test-reporter": "0.2.0",
-    "fabpot/php-cs-fixer": "2.0.*-dev",
     "henrikbjorn/phpspec-code-coverage": "~1.0",
     "phpspec/nyan-formatters": "~1.0",
     "phpspec/phpspec": "~2.2",
-    "refinery29/php-cs-fixer-config": "0.2.8"
+    "refinery29/php-cs-fixer-config": "0.4.0"
   },
   "autoload": {
     "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "0ce3804c4c49dd8451fc7f5fa3d2317c",
-    "content-hash": "e5f44c773cbb078dd60a193db99b77bd",
+    "hash": "e5548baba6220836721d23c06ce0d8ed",
+    "content-hash": "6ca300b5d32111dac67a6422cc416ad3",
     "packages": [
         {
             "name": "container-interop/container-interop",
@@ -155,7 +155,7 @@
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/route/zipball/938b33a02a5bc1e27e7a302a3d5ff63036adda4f",
+                "url": "https://api.github.com/repos/thephpleague/route/zipball/92d5abde69e3df71b91a31d9656a62034cd8d6d0",
                 "reference": "588b33bb3364a70b66fc4d63f56bda5f6d418b44",
                 "shasum": ""
             },
@@ -510,24 +510,24 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/FriendsOfPHP/PHP-CS-Fixer.git",
-                "reference": "e66847bbd397026233bde4500c76c7c997ffa5e7"
+                "reference": "518194b0e92dc75e791490b36b51cce39fe80bcf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/zipball/e66847bbd397026233bde4500c76c7c997ffa5e7",
-                "reference": "e66847bbd397026233bde4500c76c7c997ffa5e7",
+                "url": "https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/zipball/518194b0e92dc75e791490b36b51cce39fe80bcf",
+                "reference": "518194b0e92dc75e791490b36b51cce39fe80bcf",
                 "shasum": ""
             },
             "require": {
                 "ext-tokenizer": "*",
-                "php": ">=5.3.6",
-                "sebastian/diff": "~1.1",
-                "symfony/console": "~2.3|~3.0",
-                "symfony/event-dispatcher": "~2.1|~3.0",
-                "symfony/filesystem": "~2.1|~3.0",
-                "symfony/finder": "~2.1|~3.0",
-                "symfony/process": "~2.3|~3.0",
-                "symfony/stopwatch": "~2.5|~3.0"
+                "php": "^5.3.6 || ^7.0",
+                "sebastian/diff": "^1.1",
+                "symfony/console": "^2.3 || ^3.0",
+                "symfony/event-dispatcher": "^2.1 || ^3.0",
+                "symfony/filesystem": "^2.1 || ^3.0",
+                "symfony/finder": "^2.1 || ^3.0",
+                "symfony/process": "^2.3 || ^3.0",
+                "symfony/stopwatch": "^2.5 || ^3.0"
             },
             "require-dev": {
                 "satooshi/php-coveralls": "^1.0"
@@ -543,7 +543,7 @@
             },
             "autoload": {
                 "psr-4": {
-                    "Symfony\\CS\\": "src/"
+                    "PhpCsFixer\\": "src/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -561,7 +561,7 @@
                 }
             ],
             "description": "A tool to automatically fix PHP code style",
-            "time": "2016-01-03 22:51:14"
+            "time": "2016-02-01 02:32:56"
         },
         {
             "name": "guzzle/guzzle",
@@ -1210,20 +1210,20 @@
         },
         {
             "name": "refinery29/php-cs-fixer-config",
-            "version": "0.2.8",
+            "version": "0.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/refinery29/php-cs-fixer-config.git",
-                "reference": "5bdce0fcbe2771a6f79e18a12650e5033658d660"
+                "reference": "8c614d37a6e71e09762eec95b6a6c2eb0416c8e4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/refinery29/php-cs-fixer-config/zipball/5bdce0fcbe2771a6f79e18a12650e5033658d660",
-                "reference": "5bdce0fcbe2771a6f79e18a12650e5033658d660",
+                "url": "https://api.github.com/repos/refinery29/php-cs-fixer-config/zipball/8c614d37a6e71e09762eec95b6a6c2eb0416c8e4",
+                "reference": "8c614d37a6e71e09762eec95b6a6c2eb0416c8e4",
                 "shasum": ""
             },
             "require": {
-                "fabpot/php-cs-fixer": "2.0.x-dev",
+                "fabpot/php-cs-fixer": "dev-master#518194b",
                 "php": ">=5.5"
             },
             "require-dev": {
@@ -1247,7 +1247,7 @@
                 }
             ],
             "description": "Provides a configuration for fabpot/php-cs-fixer, used within Refinery29.",
-            "time": "2016-01-06 10:12:20"
+            "time": "2016-02-01 10:51:34"
         },
         {
             "name": "satooshi/php-coveralls",
@@ -2159,8 +2159,7 @@
     "minimum-stability": "dev",
     "stability-flags": {
         "league/route": 20,
-        "zendframework/zend-diactoros": 20,
-        "fabpot/php-cs-fixer": 20
+        "zendframework/zend-diactoros": 20
     },
     "prefer-stable": true,
     "prefer-lowest": false,

--- a/spec/ApiResponseSpec.php
+++ b/spec/ApiResponseSpec.php
@@ -6,7 +6,6 @@
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  */
-
 namespace spec\Refinery29\Piston;
 
 use PhpSpec\ObjectBehavior;

--- a/spec/CookieJarSpec.php
+++ b/spec/CookieJarSpec.php
@@ -6,7 +6,6 @@
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  */
-
 namespace spec\Refinery29\Piston;
 
 use PhpSpec\ObjectBehavior;

--- a/spec/Middleware/PayloadSpec.php
+++ b/spec/Middleware/PayloadSpec.php
@@ -6,7 +6,6 @@
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  */
-
 namespace spec\Refinery29\Piston\Middleware;
 
 use PhpSpec\ObjectBehavior;

--- a/spec/Middleware/PipelineProcessorSpec.php
+++ b/spec/Middleware/PipelineProcessorSpec.php
@@ -6,7 +6,6 @@
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  */
-
 namespace spec\Refinery29\Piston\Middleware;
 
 use League\Pipeline\Pipeline;

--- a/spec/Middleware/Request/IncludedResourceSpec.php
+++ b/spec/Middleware/Request/IncludedResourceSpec.php
@@ -6,7 +6,6 @@
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  */
-
 namespace spec\Refinery29\Piston\Middleware\Request;
 
 use League\Route\Http\Exception\BadRequestException;

--- a/spec/Middleware/Request/Pagination/CursorBasedPaginationSpec.php
+++ b/spec/Middleware/Request/Pagination/CursorBasedPaginationSpec.php
@@ -6,7 +6,6 @@
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  */
-
 namespace spec\Refinery29\Piston\Middleware\Request\Pagination;
 
 use League\Route\Http\Exception\BadRequestException;

--- a/spec/Middleware/Request/Pagination/OffsetLimitPaginationSpec.php
+++ b/spec/Middleware/Request/Pagination/OffsetLimitPaginationSpec.php
@@ -6,7 +6,6 @@
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  */
-
 namespace spec\Refinery29\Piston\Middleware\Request\Pagination;
 
 use League\Route\Http\Exception\BadRequestException;

--- a/spec/Middleware/Request/RequestPipelineSpec.php
+++ b/spec/Middleware/Request/RequestPipelineSpec.php
@@ -6,7 +6,6 @@
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  */
-
 namespace spec\Refinery29\Piston\Middleware\Request;
 
 use PhpSpec\ObjectBehavior;

--- a/spec/Middleware/Request/RequestedFieldsSpec.php
+++ b/spec/Middleware/Request/RequestedFieldsSpec.php
@@ -6,7 +6,6 @@
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  */
-
 namespace spec\Refinery29\Piston\Middleware\Request;
 
 use PhpSpec\ObjectBehavior;

--- a/spec/Middleware/Request/SortsSpec.php
+++ b/spec/Middleware/Request/SortsSpec.php
@@ -6,7 +6,6 @@
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  */
-
 namespace spec\Refinery29\Piston\Middleware\Request;
 
 use League\Route\Http\Exception\BadRequestException;

--- a/spec/PistonSpec.php
+++ b/spec/PistonSpec.php
@@ -6,7 +6,6 @@
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  */
-
 namespace spec\Refinery29\Piston;
 
 use League\Container\Container;

--- a/spec/RequestSpec.php
+++ b/spec/RequestSpec.php
@@ -6,7 +6,6 @@
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  */
-
 namespace spec\Refinery29\Piston;
 
 use PhpSpec\ObjectBehavior;

--- a/spec/Router/MiddlewareStrategySpec.php
+++ b/spec/Router/MiddlewareStrategySpec.php
@@ -6,7 +6,6 @@
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  */
-
 namespace spec\Refinery29\Piston\Router;
 
 use League\Container\ContainerInterface;

--- a/spec/Router/RouteGroupSpec.php
+++ b/spec/Router/RouteGroupSpec.php
@@ -6,7 +6,6 @@
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  */
-
 namespace spec\Refinery29\Piston\Router;
 
 use League\Pipeline\StageInterface;

--- a/spec/Router/RouteSpec.php
+++ b/spec/Router/RouteSpec.php
@@ -6,7 +6,6 @@
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  */
-
 namespace spec\Refinery29\Piston\Router;
 
 use League\Pipeline\StageInterface;

--- a/spec/stubs/FooController.php
+++ b/spec/stubs/FooController.php
@@ -6,7 +6,6 @@
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  */
-
 namespace Refinery29\Piston\Stubs;
 
 use Refinery29\ApiOutput\Resource\ResourceFactory;

--- a/spec/stubs/ReturnEmitter.php
+++ b/spec/stubs/ReturnEmitter.php
@@ -6,7 +6,6 @@
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  */
-
 namespace Refinery29\Piston\Stubs;
 
 use Psr\Http\Message\ResponseInterface;

--- a/spec/stubs/StringEmitter.php
+++ b/spec/stubs/StringEmitter.php
@@ -6,7 +6,6 @@
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  */
-
 namespace Refinery29\Piston\Stubs;
 
 use Psr\Http\Message\ResponseInterface;

--- a/spec/stubs/TestException.php
+++ b/spec/stubs/TestException.php
@@ -6,7 +6,6 @@
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  */
-
 namespace Refinery29\Piston\Stubs;
 
 class TestException extends \Exception

--- a/src/ApiResponse.php
+++ b/src/ApiResponse.php
@@ -6,7 +6,6 @@
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  */
-
 namespace Refinery29\Piston;
 
 use Psr\Http\Message\StreamInterface;

--- a/src/CompiledResponse.php
+++ b/src/CompiledResponse.php
@@ -6,7 +6,6 @@
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  */
-
 namespace Refinery29\Piston;
 
 interface CompiledResponse

--- a/src/CookieJar.php
+++ b/src/CookieJar.php
@@ -6,7 +6,6 @@
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  */
-
 namespace Refinery29\Piston;
 
 class CookieJar

--- a/src/Middleware/ExceptionalPipeline.php
+++ b/src/Middleware/ExceptionalPipeline.php
@@ -6,7 +6,6 @@
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  */
-
 namespace Refinery29\Piston\Middleware;
 
 use InvalidArgumentException;

--- a/src/Middleware/GetOnlyStage.php
+++ b/src/Middleware/GetOnlyStage.php
@@ -6,7 +6,6 @@
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  */
-
 namespace Refinery29\Piston\Middleware;
 
 use League\Route\Http\Exception\BadRequestException;

--- a/src/Middleware/HasMiddleware.php
+++ b/src/Middleware/HasMiddleware.php
@@ -6,7 +6,6 @@
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  */
-
 namespace Refinery29\Piston\Middleware;
 
 use League\Pipeline\StageInterface;

--- a/src/Middleware/HasMiddlewareTrait.php
+++ b/src/Middleware/HasMiddlewareTrait.php
@@ -6,7 +6,6 @@
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  */
-
 namespace Refinery29\Piston\Middleware;
 
 use League\Pipeline\Pipeline;

--- a/src/Middleware/Payload.php
+++ b/src/Middleware/Payload.php
@@ -6,7 +6,6 @@
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  */
-
 namespace Refinery29\Piston\Middleware;
 
 use Refinery29\Piston\ApiResponse;

--- a/src/Middleware/PipelineProcessor.php
+++ b/src/Middleware/PipelineProcessor.php
@@ -6,7 +6,6 @@
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  */
-
 namespace Refinery29\Piston\Middleware;
 
 class PipelineProcessor

--- a/src/Middleware/Request/IncludedResource.php
+++ b/src/Middleware/Request/IncludedResource.php
@@ -6,7 +6,6 @@
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  */
-
 namespace Refinery29\Piston\Middleware\Request;
 
 use League\Pipeline\StageInterface;

--- a/src/Middleware/Request/Pagination/CursorBasedPagination.php
+++ b/src/Middleware/Request/Pagination/CursorBasedPagination.php
@@ -6,7 +6,6 @@
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  */
-
 namespace Refinery29\Piston\Middleware\Request\Pagination;
 
 use League\Pipeline\StageInterface;

--- a/src/Middleware/Request/Pagination/OffsetLimitPagination.php
+++ b/src/Middleware/Request/Pagination/OffsetLimitPagination.php
@@ -6,7 +6,6 @@
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  */
-
 namespace Refinery29\Piston\Middleware\Request\Pagination;
 
 use League\Pipeline\StageInterface;

--- a/src/Middleware/Request/Pagination/SinglePagination.php
+++ b/src/Middleware/Request/Pagination/SinglePagination.php
@@ -6,7 +6,6 @@
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  */
-
 namespace Refinery29\Piston\Middleware\Request\Pagination;
 
 use League\Route\Http\Exception\BadRequestException;

--- a/src/Middleware/Request/RequestPipeline.php
+++ b/src/Middleware/Request/RequestPipeline.php
@@ -6,7 +6,6 @@
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  */
-
 namespace Refinery29\Piston\Middleware\Request;
 
 use League\Pipeline\Pipeline;

--- a/src/Middleware/Request/RequestedFields.php
+++ b/src/Middleware/Request/RequestedFields.php
@@ -6,7 +6,6 @@
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  */
-
 namespace Refinery29\Piston\Middleware\Request;
 
 use League\Pipeline\StageInterface;

--- a/src/Middleware/Request/Sorts.php
+++ b/src/Middleware/Request/Sorts.php
@@ -6,7 +6,6 @@
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  */
-
 namespace Refinery29\Piston\Middleware\Request;
 
 use League\Pipeline\StageInterface;

--- a/src/Piston.php
+++ b/src/Piston.php
@@ -6,7 +6,6 @@
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  */
-
 namespace Refinery29\Piston;
 
 use League\Container\Container;

--- a/src/PistonException.php
+++ b/src/PistonException.php
@@ -6,7 +6,6 @@
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  */
-
 namespace Refinery29\Piston;
 
 class PistonException extends \Exception

--- a/src/Request.php
+++ b/src/Request.php
@@ -6,7 +6,6 @@
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  */
-
 namespace Refinery29\Piston;
 
 use Zend\Diactoros\ServerRequest;

--- a/src/RequestFactory.php
+++ b/src/RequestFactory.php
@@ -6,7 +6,6 @@
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  */
-
 namespace Refinery29\Piston;
 
 use Zend\Diactoros\ServerRequestFactory;

--- a/src/ResponseInterface.php
+++ b/src/ResponseInterface.php
@@ -6,7 +6,6 @@
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  */
-
 namespace Refinery29\Piston;
 
 use Refinery29\ApiOutput\Resource\Error\ErrorCollection;

--- a/src/Router/MiddlewareStrategy.php
+++ b/src/Router/MiddlewareStrategy.php
@@ -6,7 +6,6 @@
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  */
-
 namespace Refinery29\Piston\Router;
 
 use League\Route\Route;

--- a/src/Router/Route.php
+++ b/src/Router/Route.php
@@ -6,7 +6,6 @@
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  */
-
 namespace Refinery29\Piston\Router;
 
 use Refinery29\Piston\Middleware\HasMiddleware;

--- a/src/Router/RouteGroup.php
+++ b/src/Router/RouteGroup.php
@@ -6,7 +6,6 @@
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  */
-
 namespace Refinery29\Piston\Router;
 
 use Refinery29\Piston\Middleware\HasMiddleware;


### PR DESCRIPTION
This PR

* [x] updates `refinery29/php-cs-fixer-config`
* [x] adjusts `Makefile` and `.travis.yml`
* [x] runs `make cs`

Follows https://github.com/refinery29/php-cs-fixer-config/releases/tag/0.4.0.