### PR TITLE
Fix: Add it target

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,4 +38,14 @@ Run
 $ make test
 ```
 
+## Extra lazy?
+
+Run
+
+```
+$ make
+```
+
+to run both coding standards check and tests!
+
 **Happy coding**!

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+it: cs test
+
 composer:
 	composer install
 


### PR DESCRIPTION
This PR

* [x] adds an `it` target to `Makefile`, depending on `cs` and `test` targets, and makes it the first target

:information_desk_person: Run

```
$ make
```