### PR TITLE
Update Piston's Request and Response objects after Middleware Pipelines Finish Processing

### DIFF
--- a/src/Piston.php
+++ b/src/Piston.php
@@ -174,12 +174,20 @@ class Piston extends RouteCollection implements Middleware\HasMiddleware
 
     private function processPipeline()
     {
-        (new Middleware\PipelineProcessor())->handlePayload($this->buildPayload());
+        $payload = (new Middleware\PipelineProcessor())
+            ->handlePayload($this->buildPayload());
+
+        $this->request = $payload->getRequest();
+        $this->response = $payload->getResponse();
     }
 
     private function loadContainer()
     {
-        (new Middleware\Request\RequestPipeline())->process($this->buildPayload());
+        $payload = (new Middleware\Request\RequestPipeline())
+            ->process($this->buildPayload());
+
+        $this->request = $payload->getRequest();
+        $this->response = $payload->getResponse();
 
         $this->container->add(Request::class, $this->request, true);
         $this->container->add(ApiResponse::class, $this->response, true);


### PR DESCRIPTION
## Summary

This change became required after completing `cbc843g` in https://github.com/refinery29/piston/pull/121cbc843f. That work changes Piston to work in an immutable manner, as the underling ServerRequest does.

The reason why is that the original objects are changed during processing pipelines. But when working immutably, if changes are made during the pipeline, the original object is replaced with a _new_ object, which contains all of the state of the original, as well as the required changes.

Therefore, any changes made will be lost as, for all intents and purposes, without this change, we're making changes to a copy of the request and response. So after the processing is complete, the changes will be lost. Given that, we have to be more pedantic in how the object is used throughout the application call stack. 

Specifically, the request, and response objects will now have to be returned after the respective pipelines have finished processing, so that Piston can be updated with them. I hope all this made sense.

## Specifics

This PR makes the following changes:

- [x] Updates Piston's request and response objects with those in the returned `Payload` object after pipeline processing has completed