### PR TITLE
Fix: Create specific configuration without coverage generation

### DIFF
--- a/phpspec.with-coverage.yml.dist
+++ b/phpspec.with-coverage.yml.dist
@@ -5,5 +5,14 @@ suites:
 
 extensions:
     - PhpSpec\NyanFormattersExtension\Extension
+    - PhpSpec\Extension\CodeCoverageExtension
 
 formatter.name: nyan.cat
+
+code_coverage:
+  format:
+    - html
+    - clover
+  output:
+    html: coverage
+    clover: build/logs/clover.xml


### PR DESCRIPTION
This PR

* [x] renames `phpspec.yml.dist` to `phpspec.with-coverage.yml.dist`
* [x] removes coverage related configuration from `phpspec.yml.dist`

Follows #123.

:information_desk_person: This allows to run specifications without xdebug installed.