### PR TITLE
Fix: Streamline Travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,9 @@ env:
 matrix:
   include:
     - php: 5.5
+      env: WITH_CS=true
     - php: 5.6
-      env: COLLECT_COVERAGE=true
+      env: WITH_COVERAGE=true
 
 cache:
   directories:
@@ -19,6 +20,8 @@ cache:
     - $HOME/.php-cs-fixer
 
 before_install:
+  - if [[ "$TRAVIS_PULL_REQUEST" == "false" && "$TRAVIS_BRANCH" == "master" ]]; then IS_MERGE_TO_MASTER=true; else IS_MERGE_TO_MASTER=false; fi
+  - if [[ "$WITH_COVERAGE" != "true" && "$IS_MERGE_TO_MASTER" == "false" && "$TRAVIS_PHP_VERSION" != "hhvm" ]]; then phpenv config-rm xdebug.ini; fi
   - composer self-update
   - composer validate
   - composer config github-oauth.github.com $GITHUB_TOKEN
@@ -28,10 +31,15 @@ install:
 
 before_script:
   - mkdir -p "$HOME/.php-cs-fixer"
+  - mkdir -p build/logs
 
 script:
-  - bin/php-cs-fixer fix --config=.php_cs --verbose --diff --dry-run
+  - if [[ "$WITH_COVERAGE" == "true" && "$IS_MERGE_TO_MASTER" == "true" ]]; then cp phpspec.with-coverage.yml.dist phpspec.yml; fi
   - bin/phpspec run --format=dot
+  - if [[ "$WITH_CS" == "true" ]]; then bin/php-cs-fixer fix --config=.php_cs --verbose --diff --dry-run; fi
 
-after_script:
-  - if [[ "$TRAVIS_PULL_REQUEST" == "false" && "$TRAVIS_BRANCH" == "master" && "$COLLECT_COVERAGE" == "true" ]]; then bin/test-reporter; fi
+after_success:
+  - if [[ "$WITH_COVERAGE" == "true" && "$IS_MERGE_TO_MASTER" == "true" ]]; then bin/test-reporter --coverage-report=build/logs/clover.xml; fi
+
+notifications:
+  email: false


### PR DESCRIPTION
This PR

* [x] streamlines the Travis configuration

Follows #124.

:information_desk_person: Running coverage only after a merge now, cuts down build time substantially.