### PR TITLE
Fix: Output text coverage

### DIFF
--- a/phpspec.with-coverage.yml.dist
+++ b/phpspec.with-coverage.yml.dist
@@ -11,8 +11,7 @@ formatter.name: nyan.cat
 
 code_coverage:
   format:
-    - html
+    - text
     - clover
   output:
-    html: coverage
     clover: build/logs/clover.xml


### PR DESCRIPTION
This PR

* [x] outputs coverage in `text` format instead of `html`