### PR TITLE
Fix: Add coverage target

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,6 +38,14 @@ Run
 $ make test
 ```
 
+Run
+
+```
+$ make coverage
+```
+
+if you are interested in code coverage.
+
 ## Extra lazy?
 
 Run

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,11 @@ it: cs test
 composer:
 	composer install
 
+coverage: composer
+	cp phpspec.with-coverage.yml.dist phpspec.yml
+	bin/phpspec run
+	rm phpspec.yml
+
 cs: composer
 	bin/php-cs-fixer fix --config=.php_cs --verbose --diff
 


### PR DESCRIPTION
This PR

* [x] adds a `coverage` target to `Makefile`

:information_desk_person: Run

```
$ make coverage
```