### PR TITLE
Fix: Mix in system under test

### DIFF
--- a/spec/ApiResponseSpec.php
+++ b/spec/ApiResponseSpec.php
@@ -17,6 +17,9 @@ use Refinery29\ApiOutput\ResponseBody;
 use Refinery29\Piston\ApiResponse;
 use Zend\Diactoros\Stream;
 
+/**
+ * @mixin ApiResponse
+ */
 class ApiResponseSpec extends ObjectBehavior
 {
     public function it_can_be_constructed_without_response_body(Stream $stream)

--- a/spec/CookieJarSpec.php
+++ b/spec/CookieJarSpec.php
@@ -11,6 +11,9 @@ namespace spec\Refinery29\Piston;
 use PhpSpec\ObjectBehavior;
 use Refinery29\Piston\CookieJar;
 
+/**
+ * @mixin CookieJar
+ */
 class CookieJarSpec extends ObjectBehavior
 {
     public function it_is_initializable()

--- a/spec/Middleware/PayloadSpec.php
+++ b/spec/Middleware/PayloadSpec.php
@@ -14,6 +14,9 @@ use Refinery29\Piston\Middleware\HasMiddleware;
 use Refinery29\Piston\Middleware\Payload;
 use Refinery29\Piston\Request;
 
+/**
+ * @mixin Payload
+ */
 class PayloadSpec extends ObjectBehavior
 {
     public function let(HasMiddleware $subject, Request $request, ApiResponse $response)

--- a/spec/Middleware/PipelineProcessorSpec.php
+++ b/spec/Middleware/PipelineProcessorSpec.php
@@ -12,9 +12,13 @@ use League\Pipeline\Pipeline;
 use PhpSpec\ObjectBehavior;
 use Refinery29\Piston\ApiResponse;
 use Refinery29\Piston\Middleware\Payload;
+use Refinery29\Piston\Middleware\PipelineProcessor;
 use Refinery29\Piston\Piston;
 use Refinery29\Piston\Request;
 
+/**
+ * @mixin PipelineProcessor
+ */
 class PipelineProcessorSpec extends ObjectBehavior
 {
     public function it_handles_a_subject(Piston $middleware)

--- a/spec/Middleware/Request/IncludedResourceSpec.php
+++ b/spec/Middleware/Request/IncludedResourceSpec.php
@@ -16,6 +16,9 @@ use Refinery29\Piston\Middleware\Request\IncludedResource;
 use Refinery29\Piston\Piston;
 use Refinery29\Piston\Request;
 
+/**
+ * @mixin IncludedResource
+ */
 class IncludedResourceSpec extends ObjectBehavior
 {
     public function it_is_initializable()

--- a/spec/Middleware/Request/Pagination/CursorBasedPaginationSpec.php
+++ b/spec/Middleware/Request/Pagination/CursorBasedPaginationSpec.php
@@ -16,6 +16,9 @@ use Refinery29\Piston\Middleware\Request\Pagination\CursorBasedPagination;
 use Refinery29\Piston\Piston;
 use Refinery29\Piston\RequestFactory;
 
+/**
+ * @mixin CursorBasedPagination
+ */
 class CursorBasedPaginationSpec extends ObjectBehavior
 {
     public function it_is_initializable()

--- a/spec/Middleware/Request/Pagination/OffsetLimitPaginationSpec.php
+++ b/spec/Middleware/Request/Pagination/OffsetLimitPaginationSpec.php
@@ -16,6 +16,9 @@ use Refinery29\Piston\Middleware\Request\Pagination\OffsetLimitPagination;
 use Refinery29\Piston\Piston;
 use Refinery29\Piston\RequestFactory;
 
+/**
+ * @mixin OffsetLimitPagination
+ */
 class OffsetLimitPaginationSpec extends ObjectBehavior
 {
     public function it_is_initializable()

--- a/spec/Middleware/Request/RequestPipelineSpec.php
+++ b/spec/Middleware/Request/RequestPipelineSpec.php
@@ -15,6 +15,9 @@ use Refinery29\Piston\Middleware\Request\RequestPipeline;
 use Refinery29\Piston\Piston;
 use Refinery29\Piston\Request;
 
+/**
+ * @mixin RequestPipeline
+ */
 class RequestPipelineSpec extends ObjectBehavior
 {
     public function it_is_initializable()

--- a/spec/Middleware/Request/RequestedFieldsSpec.php
+++ b/spec/Middleware/Request/RequestedFieldsSpec.php
@@ -15,6 +15,9 @@ use Refinery29\Piston\Middleware\Request\RequestedFields;
 use Refinery29\Piston\Piston;
 use Refinery29\Piston\Request;
 
+/**
+ * @mixin RequestedFields
+ */
 class RequestedFieldsSpec extends ObjectBehavior
 {
     public function it_is_initializable()

--- a/spec/Middleware/Request/SortsSpec.php
+++ b/spec/Middleware/Request/SortsSpec.php
@@ -16,6 +16,9 @@ use Refinery29\Piston\Middleware\Request\Sorts;
 use Refinery29\Piston\Piston;
 use Refinery29\Piston\Request;
 
+/**
+ * @mixin Sorts
+ */
 class SortsSpec extends ObjectBehavior
 {
     public function it_is_initializable()

--- a/spec/PistonSpec.php
+++ b/spec/PistonSpec.php
@@ -26,6 +26,9 @@ use Refinery29\Piston\Stubs\StringEmitter;
 use Refinery29\Piston\Stubs\TestException;
 use Zend\Diactoros\Uri;
 
+/**
+ * @mixin Piston
+ */
 class PistonSpec extends ObjectBehavior
 {
     public function let(Container $container)

--- a/spec/RequestSpec.php
+++ b/spec/RequestSpec.php
@@ -12,6 +12,9 @@ use PhpSpec\ObjectBehavior;
 use Refinery29\Piston\CookieJar;
 use Refinery29\Piston\Request;
 
+/**
+ * @mixin Request
+ */
 class RequestSpec extends ObjectBehavior
 {
     public function it_is_initializable()

--- a/spec/Router/MiddlewareStrategySpec.php
+++ b/spec/Router/MiddlewareStrategySpec.php
@@ -19,6 +19,9 @@ use Refinery29\Piston\Router\Route;
 use Refinery29\Piston\Router\RouteGroup;
 use Refinery29\Piston\Stubs\FooController;
 
+/**
+ * @mixin MiddlewareStrategy
+ */
 class MiddlewareStrategySpec extends ObjectBehavior
 {
     public function let(ContainerInterface $container)

--- a/spec/Router/RouteGroupSpec.php
+++ b/spec/Router/RouteGroupSpec.php
@@ -15,6 +15,9 @@ use League\Route\RouteGroup;
 use PhpSpec\ObjectBehavior;
 use Refinery29\Piston\Middleware\ExceptionalPipeline;
 
+/**
+ * @mixin RouteGroup
+ */
 class RouteGroupSpec extends ObjectBehavior
 {
     public function let()

--- a/spec/Router/RouteSpec.php
+++ b/spec/Router/RouteSpec.php
@@ -13,6 +13,9 @@ use PhpSpec\ObjectBehavior;
 use Refinery29\Piston\Middleware\ExceptionalPipeline;
 use Refinery29\Piston\Router\Route;
 
+/**
+ * @mixin Route
+ */
 class RouteSpec extends ObjectBehavior
 {
     public function it_is_initializable()


### PR DESCRIPTION
This PR

* [x] mixes in the the system under test

:information_desk_person: This greatly improves developer convenience as now it is possible to navigate to the methods invoked on the system under test.