### PR TITLE
Fix: No need to assign null as default value

### DIFF
--- a/src/Middleware/HasMiddlewareTrait.php
+++ b/src/Middleware/HasMiddlewareTrait.php
@@ -16,7 +16,7 @@ trait HasMiddlewareTrait
     /**
      * @var ExceptionalPipeline
      */
-    protected $pipeline = null;
+    protected $pipeline;
 
     /**
      * @var StageInterface[]

--- a/src/Piston.php
+++ b/src/Piston.php
@@ -27,7 +27,7 @@ class Piston extends RouteCollection implements Middleware\HasMiddleware
     /**
      * @var Request
      */
-    private $request = null;
+    private $request;
 
     /**
      * @var ApiResponse

--- a/src/Request.php
+++ b/src/Request.php
@@ -41,22 +41,22 @@ class Request extends ServerRequest
     /**
      * @var null
      */
-    protected $paginationCursor = null;
+    protected $paginationCursor;
 
     /**
      * @var string
      */
-    protected $paginationType = null;
+    protected $paginationType;
 
     /**
      * @var array
      */
-    protected $requestedFields = null;
+    protected $requestedFields;
 
     /**
      * @var array
      */
-    protected $includedResources = null;
+    protected $includedResources;
 
     /**
      * @var string
@@ -86,7 +86,7 @@ class Request extends ServerRequest
     /**
      * @var array
      */
-    private $sorts = null;
+    private $sorts;
 
     /**
      * @return array


### PR DESCRIPTION
This PR

* [x] removes assignments of `null` to class members

:information_desk_person: It's the default.