### PR TITLE
Fix: Streamline .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,14 +1,17 @@
 root = true
 
 [*]
-end_of_line = lf
 charset = utf-8
-trim_trailing_whitespace = true
-insert_final_newline = true
-
-[**.php]
-indent_style = space
 indent_size = 4
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.yml]
+indent_size = 2
 
 [Makefile]
 indent_style = tab


### PR DESCRIPTION
This PR

* [x] streamlines `.editorconfig`, in particular adds a section for `yml` files