### PR TITLE
Fix: Consistently indent yml with 2 spaces

### DIFF
--- a/phpspec.with-coverage.yml
+++ b/phpspec.with-coverage.yml
@@ -1,11 +1,11 @@
 suites:
-    piston:
-        namespace: Refinery29\Piston
-        psr4_prefix: Refinery29\Piston
+  piston:
+    namespace: Refinery29\Piston
+    psr4_prefix: Refinery29\Piston
 
 extensions:
-    - PhpSpec\NyanFormattersExtension\Extension
-    - PhpSpec\Extension\CodeCoverageExtension
+  - PhpSpec\NyanFormattersExtension\Extension
+  - PhpSpec\Extension\CodeCoverageExtension
 
 formatter.name: nyan.cat
 

--- a/phpspec.yml
+++ b/phpspec.yml
@@ -1,9 +1,9 @@
 suites:
-    piston:
-        namespace: Refinery29\Piston
-        psr4_prefix: Refinery29\Piston
+  piston:
+    namespace: Refinery29\Piston
+    psr4_prefix: Refinery29\Piston
 
 extensions:
-    - PhpSpec\NyanFormattersExtension\Extension
+  - PhpSpec\NyanFormattersExtension\Extension
 
 formatter.name: nyan.cat


### PR DESCRIPTION
This PR

* [x] consistently indents `yml` files with 2 spaces

Follows https://github.com/refinery29/piston/pull/137.