### PR TITLE
Fix: Move stubs into appropriate namespace

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
   },
   "autoload-dev": {
     "psr-4": {
-      "Refinery29\\Piston\\Stubs\\": "spec/Stubs"
+      "spec\\Refinery29\\Piston\\": "spec"
     }
   },
   "minimum-stability": "dev",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "2d42d2ac3cab95b56b6121b80cebb703",
+    "hash": "3e2d45503d7fe5514ad0a6b66378733e",
     "content-hash": "0a9f97e371e0e080b32700794c3c79bb",
     "packages": [
         {

--- a/spec/PistonSpec.php
+++ b/spec/PistonSpec.php
@@ -20,10 +20,10 @@ use Refinery29\Piston\Piston;
 use Refinery29\Piston\Request;
 use Refinery29\Piston\RequestFactory;
 use Refinery29\Piston\Router\RouteGroup;
-use Refinery29\Piston\Stubs\FooController;
-use Refinery29\Piston\Stubs\ReturnEmitter;
-use Refinery29\Piston\Stubs\StringEmitter;
-use Refinery29\Piston\Stubs\TestException;
+use spec\Refinery29\Piston\Stubs\FooController;
+use spec\Refinery29\Piston\Stubs\ReturnEmitter;
+use spec\Refinery29\Piston\Stubs\StringEmitter;
+use spec\Refinery29\Piston\Stubs\TestException;
 use Zend\Diactoros\Uri;
 
 /**

--- a/spec/Router/MiddlewareStrategySpec.php
+++ b/spec/Router/MiddlewareStrategySpec.php
@@ -17,7 +17,7 @@ use Refinery29\Piston\RequestFactory;
 use Refinery29\Piston\Router\MiddlewareStrategy;
 use Refinery29\Piston\Router\Route;
 use Refinery29\Piston\Router\RouteGroup;
-use Refinery29\Piston\Stubs\FooController;
+use spec\Refinery29\Piston\Stubs\FooController;
 
 /**
  * @mixin MiddlewareStrategy

--- a/spec/Stubs/FooController.php
+++ b/spec/Stubs/FooController.php
@@ -6,7 +6,7 @@
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  */
-namespace Refinery29\Piston\Stubs;
+namespace spec\Refinery29\Piston\Stubs;
 
 use Refinery29\ApiOutput\Resource\ResourceFactory;
 use Refinery29\Piston\ApiResponse;

--- a/spec/Stubs/ReturnEmitter.php
+++ b/spec/Stubs/ReturnEmitter.php
@@ -6,7 +6,7 @@
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  */
-namespace Refinery29\Piston\Stubs;
+namespace spec\Refinery29\Piston\Stubs;
 
 use Psr\Http\Message\ResponseInterface;
 use Zend\Diactoros\Response\EmitterInterface;

--- a/spec/Stubs/StringEmitter.php
+++ b/spec/Stubs/StringEmitter.php
@@ -6,7 +6,7 @@
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  */
-namespace Refinery29\Piston\Stubs;
+namespace spec\Refinery29\Piston\Stubs;
 
 use Psr\Http\Message\ResponseInterface;
 use Zend\Diactoros\Response\EmitterInterface;

--- a/spec/Stubs/TestException.php
+++ b/spec/Stubs/TestException.php
@@ -6,7 +6,7 @@
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  */
-namespace Refinery29\Piston\Stubs;
+namespace spec\Refinery29\Piston\Stubs;
 
 class TestException extends \Exception
 {


### PR DESCRIPTION
This PR

* [x] moves stubs into the appropriate namespace and fixes the autoloading