### PR TITLE
Fix: Use singular for namespace

### DIFF
--- a/spec/PistonSpec.php
+++ b/spec/PistonSpec.php
@@ -20,10 +20,10 @@ use Refinery29\Piston\Piston;
 use Refinery29\Piston\Request;
 use Refinery29\Piston\RequestFactory;
 use Refinery29\Piston\Router\RouteGroup;
-use spec\Refinery29\Piston\Stubs\FooController;
-use spec\Refinery29\Piston\Stubs\ReturnEmitter;
-use spec\Refinery29\Piston\Stubs\StringEmitter;
-use spec\Refinery29\Piston\Stubs\TestException;
+use spec\Refinery29\Piston\Stub\FooController;
+use spec\Refinery29\Piston\Stub\ReturnEmitter;
+use spec\Refinery29\Piston\Stub\StringEmitter;
+use spec\Refinery29\Piston\Stub\TestException;
 use Zend\Diactoros\Uri;
 
 /**

--- a/spec/Router/MiddlewareStrategySpec.php
+++ b/spec/Router/MiddlewareStrategySpec.php
@@ -17,7 +17,7 @@ use Refinery29\Piston\RequestFactory;
 use Refinery29\Piston\Router\MiddlewareStrategy;
 use Refinery29\Piston\Router\Route;
 use Refinery29\Piston\Router\RouteGroup;
-use spec\Refinery29\Piston\Stubs\FooController;
+use spec\Refinery29\Piston\Stub\FooController;
 
 /**
  * @mixin MiddlewareStrategy

--- a/spec/Stub/FooController.php
+++ b/spec/Stub/FooController.php
@@ -6,7 +6,7 @@
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  */
-namespace spec\Refinery29\Piston\Stubs;
+namespace spec\Refinery29\Piston\Stub;
 
 use Refinery29\ApiOutput\Resource\ResourceFactory;
 use Refinery29\Piston\ApiResponse;

--- a/spec/Stub/ReturnEmitter.php
+++ b/spec/Stub/ReturnEmitter.php
@@ -6,7 +6,7 @@
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  */
-namespace spec\Refinery29\Piston\Stubs;
+namespace spec\Refinery29\Piston\Stub;
 
 use Psr\Http\Message\ResponseInterface;
 use Zend\Diactoros\Response\EmitterInterface;

--- a/spec/Stub/StringEmitter.php
+++ b/spec/Stub/StringEmitter.php
@@ -6,7 +6,7 @@
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  */
-namespace spec\Refinery29\Piston\Stubs;
+namespace spec\Refinery29\Piston\Stub;
 
 use Psr\Http\Message\ResponseInterface;
 use Zend\Diactoros\Response\EmitterInterface;

--- a/spec/Stub/TestException.php
+++ b/spec/Stub/TestException.php
@@ -6,7 +6,7 @@
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  */
-namespace spec\Refinery29\Piston\Stubs;
+namespace spec\Refinery29\Piston\Stub;
 
 class TestException extends \Exception
 {


### PR DESCRIPTION
This PR

* [x] uses `Stub` instead of `Stubs` for a namespace segment