### PR TITLE
Fix: Mix in the subject into the specification

### DIFF
--- a/.phpspec/specification.tpl
+++ b/.phpspec/specification.tpl
@@ -5,6 +5,9 @@ namespace %namespace%;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 
+/**
+ * @mixin \%subject%
+ */
 class %name% extends ObjectBehavior
 {
     function it_is_initializable()


### PR DESCRIPTION
This PR

* [x] adjusts the specification template to mix in the subject

Follows #130.