### PR TITLE
Fix: Use class keyword

### DIFF
--- a/spec/Middleware/Request/Pagination/CursorBasedPaginationSpec.php
+++ b/spec/Middleware/Request/Pagination/CursorBasedPaginationSpec.php
@@ -30,14 +30,14 @@ class CursorBasedPaginationSpec extends ObjectBehavior
     {
         $request = RequestFactory::fromGlobals()->withMethod('PUT')->withQueryParams(['before' => 123]);
 
-        $this->shouldThrow('League\Route\Http\Exception\BadRequestException')->during('process', [$this->getPayload($request, $middleware)]);
+        $this->shouldThrow(BadRequestException::class)->during('process', [$this->getPayload($request, $middleware)]);
     }
 
     public function it_will_not_allow_before_an_after(Piston $middleware)
     {
         $request = RequestFactory::fromGlobals()->withQueryParams(['before' => 123, 'after' => 456]);
 
-        $this->shouldThrow('League\Route\Http\Exception\BadRequestException')->during('process', [$this->getPayload($request, $middleware)]);
+        $this->shouldThrow(BadRequestException::class)->during('process', [$this->getPayload($request, $middleware)]);
     }
 
     public function it_will_allow_before_cursor_on_get_requests(Piston $middleware)

--- a/spec/Middleware/Request/Pagination/OffsetLimitPaginationSpec.php
+++ b/spec/Middleware/Request/Pagination/OffsetLimitPaginationSpec.php
@@ -30,7 +30,7 @@ class OffsetLimitPaginationSpec extends ObjectBehavior
     {
         $request = RequestFactory::fromGlobals()->withQueryParams(['limit' => 20, 'offset' => 40])->withMethod('PUT');
 
-        $this->shouldThrow('League\Route\Http\Exception\BadRequestException')->during('process', [$this->getPayload($request, $piston)]);
+        $this->shouldThrow(BadRequestException::class)->during('process', [$this->getPayload($request, $piston)]);
     }
 
     public function it_returns_a_payload_with_request(Piston $piston)
@@ -47,7 +47,7 @@ class OffsetLimitPaginationSpec extends ObjectBehavior
         $request = RequestFactory::fromGlobals()->withQueryParams(['limit' => 20, 'offset' => 40]);
         $request->setBeforeCursor('abc');
 
-        $this->shouldThrow('League\Route\Http\Exception\BadRequestException')->during('process', [$this->getPayload($request, $piston)]);
+        $this->shouldThrow(BadRequestException::class)->during('process', [$this->getPayload($request, $piston)]);
     }
 
     public function it_assigns_limit_to_request_as_integer(Piston $piston)
@@ -86,27 +86,27 @@ class OffsetLimitPaginationSpec extends ObjectBehavior
     {
         $request = RequestFactory::fromGlobals()->withQueryParams(['offset' => '20', 'limit' => 'nope']);
 
-        $this->shouldThrow('League\Route\Http\Exception\BadRequestException')->during('process', [$this->getPayload($request, $piston)]);
+        $this->shouldThrow(BadRequestException::class)->during('process', [$this->getPayload($request, $piston)]);
     }
 
     public function it_throws_if_limit_is_not_numeric(Piston $piston)
     {
         $request = RequestFactory::fromGlobals()->withQueryParams(['limit' => '20', 'offset' => 'nope']);
-        $this->shouldThrow('League\Route\Http\Exception\BadRequestException')->during('process', [$this->getPayload($request, $piston)]);
+        $this->shouldThrow(BadRequestException::class)->during('process', [$this->getPayload($request, $piston)]);
     }
 
     public function it_throws_if_offset_is_not_an_integer(Piston $piston)
     {
         $request = RequestFactory::fromGlobals()->withQueryParams(['limit' => '20', 'offset' => '10.34']);
 
-        $this->shouldThrow('League\Route\Http\Exception\BadRequestException')->during('process', [$this->getPayload($request, $piston)]);
+        $this->shouldThrow(BadRequestException::class)->during('process', [$this->getPayload($request, $piston)]);
     }
 
     public function it_throws_if_limit_is_not_an_integer(Piston $piston)
     {
         $request = RequestFactory::fromGlobals()->withQueryParams(['limit' => '10.35', 'offset' => '20']);
 
-        $this->shouldThrow('League\Route\Http\Exception\BadRequestException')->during('process', [$this->getPayload($request, $piston)]);
+        $this->shouldThrow(BadRequestException::class)->during('process', [$this->getPayload($request, $piston)]);
     }
 
     public function it_will_not_allow_previously_paginated_requests(Piston $piston)

--- a/spec/PistonSpec.php
+++ b/spec/PistonSpec.php
@@ -33,7 +33,7 @@ class PistonSpec extends ObjectBehavior
 {
     public function let(Container $container)
     {
-        $container->beADoubleOf('League\Container\Container');
+        $container->beADoubleOf(Container::class);
         $this->beConstructedWith($container);
     }
 
@@ -124,7 +124,7 @@ class PistonSpec extends ObjectBehavior
 
     public function it_can_add_service_providers(ServiceProvider\AbstractServiceProvider $provider)
     {
-        $provider->beADoubleOf('League\Container\ServiceProvider\AbstractServiceProvider');
+        $provider->beADoubleOf(ServiceProvider\AbstractServiceProvider::class);
 
         $this->register($provider);
     }

--- a/spec/Router/MiddlewareStrategySpec.php
+++ b/spec/Router/MiddlewareStrategySpec.php
@@ -28,7 +28,7 @@ class MiddlewareStrategySpec extends ObjectBehavior
     {
         $container->get('Request')->willReturn(RequestFactory::createFromUri('/alias'));
         $container->get('Response')->willReturn(new ApiResponse());
-        $container->get('Refinery29\Piston\Stubs\FooController')->willReturn(new FooController());
+        $container->get(FooController::class)->willReturn(new FooController());
     }
 
     public function it_is_initializable()


### PR DESCRIPTION
This PR

* [x] makes use of the `class` keyword instead of specifying class names as strings

:information_desk_person: This is part of a series, intending to clean up the specifications.