### PR TITLE
Fix: Return types in docblocks

### DIFF
--- a/spec/Stub/ReturnEmitter.php
+++ b/spec/Stub/ReturnEmitter.php
@@ -19,7 +19,7 @@ class ReturnEmitter implements EmitterInterface
      *
      * @param ResponseInterface $response
      *
-     * @return \Psr\Http\Message\StreamInterface
+     * @return ResponseInterface
      */
     public function emit(ResponseInterface $response)
     {

--- a/spec/Stub/StringEmitter.php
+++ b/spec/Stub/StringEmitter.php
@@ -19,7 +19,7 @@ class StringEmitter implements EmitterInterface
      *
      * @param ResponseInterface $response
      *
-     * @return \Psr\Http\Message\StreamInterface
+     * @return string
      */
     public function emit(ResponseInterface $response)
     {


### PR DESCRIPTION
This PR

* [x] fixes dockblocks which claim to return something different than what is actually returned