### PR TITLE
Fix: Rename ReturnEmitter to PassThroughEmitter

### DIFF
--- a/spec/PistonSpec.php
+++ b/spec/PistonSpec.php
@@ -22,7 +22,7 @@ use Refinery29\Piston\Request;
 use Refinery29\Piston\RequestFactory;
 use Refinery29\Piston\Router\RouteGroup;
 use spec\Refinery29\Piston\Stub\FooController;
-use spec\Refinery29\Piston\Stub\ReturnEmitter;
+use spec\Refinery29\Piston\Stub\PassThroughEmitter;
 use spec\Refinery29\Piston\Stub\StringEmitter;
 use spec\Refinery29\Piston\Stub\TestException;
 use Zend\Diactoros\Uri;
@@ -171,7 +171,7 @@ class PistonSpec extends ObjectBehavior
 
     public function it_returns_404_when_not_found()
     {
-        $emitter = new ReturnEmitter();
+        $emitter = new PassThroughEmitter();
         $this->beConstructedWith(null, null, $emitter);
         $response = $this->launch();
         $response->shouldHaveType(ApiResponse::class);
@@ -181,7 +181,7 @@ class PistonSpec extends ObjectBehavior
 
     public function it_returns_correct_error_code()
     {
-        $emitter = new ReturnEmitter();
+        $emitter = new PassThroughEmitter();
         $this->beConstructedWith(null, null, $emitter);
 
         $this->addMiddleware(CallableStage::forCallable(function () {
@@ -200,7 +200,7 @@ class PistonSpec extends ObjectBehavior
 
     public function it_can_return_error_response_with_custom_body()
     {
-        $emitter = new ReturnEmitter();
+        $emitter = new PassThroughEmitter();
         $this->beConstructedWith(null, null, $emitter);
 
         $this->addMiddleware(CallableStage::forCallable(function () {
@@ -228,7 +228,7 @@ class PistonSpec extends ObjectBehavior
 
     public function it_can_override_already_registered_exceptions()
     {
-        $emitter = new ReturnEmitter();
+        $emitter = new PassThroughEmitter();
         $this->beConstructedWith(null, null, $emitter);
         $response = $this->launch();
         $response->shouldHaveType(ApiResponse::class);

--- a/spec/Stub/PassThroughEmitter.php
+++ b/spec/Stub/PassThroughEmitter.php
@@ -12,7 +12,7 @@ namespace spec\Refinery29\Piston\Stub;
 use Psr\Http\Message\ResponseInterface;
 use Zend\Diactoros\Response\EmitterInterface;
 
-class ReturnEmitter implements EmitterInterface
+class PassThroughEmitter implements EmitterInterface
 {
     /**
      * Emit a response.


### PR DESCRIPTION
This PR

* [x] renames `ReturnEmitter` to `PassThroughEmitter`

Follows #149.

:information_desk_person: All emitters return something - this one, though, passes through the response object passed to it.