### PR TITLE
Fix: Pin unstable dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,9 +23,9 @@
   "require": {
     "php": ">=5.5",
     "beberlei/assert": "^2.4",
-    "league/pipeline": "^0.1.0",
+    "league/pipeline": "0.1.0",
     "league/route": "dev-develop",
-    "refinery29/api-output": "^0.3.0",
+    "refinery29/api-output": "0.3.1",
     "zendframework/zend-diactoros": "^1.3.3"
   },
   "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "299a36bc04a34160372097170ef649b0",
-    "content-hash": "4f3c81e463b17ef70a03d1527c67bac9",
+    "hash": "8abb5b8b7e3792ac00c65eaeb4d50ded",
+    "content-hash": "ba85119d5e10571037188aa22ee49e65",
     "packages": [
         {
             "name": "beberlei/assert",


### PR DESCRIPTION
This PR

* [x] pins `refinery29/api-output` to `0.3.1` and `league/pipeline` to `0.1.0` (same as currently installed)

:information_desk_person: It's generally bad practice to use a floating constraint for unstable dependencies, see http://semver.org/#spec-item-4:

> Major version zero (0.y.z) is for initial development. Anything may change at any time. The public API should not be considered stable.