### PR TITLE
Fix: Allow to indent json files with 2 spaces

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,6 +7,9 @@ indent_style = space
 insert_final_newline = true
 trim_trailing_whitespace = true
 
+[*.json]
+indent_size = 2
+
 [*.md]
 trim_trailing_whitespace = false
 


### PR DESCRIPTION
This PR

* [x] adjusts `.editorconfig` to allow indentation with 2 spaces