### PR TITLE
Fix: No need to assign and then immediately re-assign

### DIFF
--- a/src/Middleware/HasMiddlewareTrait.php
+++ b/src/Middleware/HasMiddlewareTrait.php
@@ -30,8 +30,7 @@ trait HasMiddlewareTrait
      */
     public function addMiddleware(StageInterface $stage)
     {
-        $this->pipeline = $this->getPipeline();
-        $this->pipeline = $this->pipeline->pipe($stage);
+        $this->pipeline = $this->getPipeline()->pipe($stage);
 
         return $this;
     }


### PR DESCRIPTION
This PR

* [x] skips an assignment as directly after the assignment the field is re-assigned a different value