### PR TITLE
Fix: Do not generate coverage when running specifications

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,8 +34,8 @@ before_script:
   - mkdir -p build/logs
 
 script:
-  - if [[ "$WITH_COVERAGE" == "true" && "$IS_MERGE_TO_MASTER" == "true" ]]; then bin/phpspec run --format=dot --config=phpspec.with-coverage.yml; else bin/phpspec run --format=dot --config=phpspec.yml; fi
-  - bin/phpunit --configuration test/Unit/phpunit.xml
+  - bin/phpspec run --format=dot --config=phpspec.yml
+  - if [[ "$WITH_COVERAGE" == "true" && "$IS_MERGE_TO_MASTER" == "true" ]]; then bin/phpunit --configuration=test/Unit/phpunit.xml --coverage-clover=build/logs/clover.xml; else bin/phpunit --configuration=test/Unit/phpunit.xml; fi
   - if [[ "$WITH_CS" == "true" ]]; then bin/php-cs-fixer fix --config=.php_cs --verbose --diff --dry-run; fi
 
 after_success:

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ composer:
 	composer install
 
 coverage: composer
-	bin/phpspec run --config phpspec.with-coverage.yml
+	bin/phpunit --configuration test/Unit/phpunit.xml --coverage-text
 
 cs: composer
 	bin/php-cs-fixer fix --config=.php_cs --verbose --diff


### PR DESCRIPTION
This PR

* [x] generates coverage from running unit tests

Follows #161.

:information_desk_person: The coverage generated from running specifications is in fact misleading, as a lot of code is only indirectly tested as part of integration tests. Coverage should only be generated from unit tests, though.