### PR TITLE
Fix: Remove irrelevant entry from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 /bin
 /build
-/coverage
 /vendor/
 .idea/
 .php_cs.cache


### PR DESCRIPTION
This PR

* [x] removes an irrelevant entry from `.gitignore`