### PR TITLE
Fix: Allow to clear cookie when the value for the key is null

### DIFF
--- a/src/CookieJar.php
+++ b/src/CookieJar.php
@@ -55,9 +55,11 @@ class CookieJar
      */
     public function clear($key)
     {
-        if (isset($this->cookies[$key])) {
-            unset($this->cookies[$key]);
+        if (!array_key_exists($key, $this->cookies)) {
+            return;
         }
+
+        unset($this->cookies[$key]);
     }
 
     public function clearAll()

--- a/test/Unit/CookieJarTest.php
+++ b/test/Unit/CookieJarTest.php
@@ -73,6 +73,21 @@ class CookieJarTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($cookies, $cookieJar->all());
     }
 
+    public function testCanClearCookieWhereValueIsNull()
+    {
+        $key = $this->getFaker()->word;
+
+        $cookies = [
+            $key => null,
+        ];
+
+        $cookieJar = new CookieJar($cookies);
+
+        $cookieJar->clear($key);
+
+        $this->assertSame([], $cookieJar->all());
+    }
+
     public function testCanClearAllCookies()
     {
         $cookies = $this->cookies();


### PR DESCRIPTION
This PR

* [x] asserts that a cookie can be cleared if the value is `null`
* [x] allows to clear a cookie when the value is `null`

Follows #172.