### PR TITLE
Fix: Assert that cookie can be cleared even if key does not exist

### DIFF
--- a/src/CookieJar.php
+++ b/src/CookieJar.php
@@ -55,10 +55,6 @@ class CookieJar
      */
     public function clear($key)
     {
-        if (!array_key_exists($key, $this->cookies)) {
-            return;
-        }
-
         unset($this->cookies[$key]);
     }
 

--- a/test/Unit/CookieJarTest.php
+++ b/test/Unit/CookieJarTest.php
@@ -88,6 +88,17 @@ class CookieJarTest extends \PHPUnit_Framework_TestCase
         $this->assertSame([], $cookieJar->all());
     }
 
+    public function testCanClearCookieEvenIfKeyDoesNotExist()
+    {
+        $key = $this->getFaker()->word;
+
+        $cookieJar = new CookieJar();
+
+        $cookieJar->clear($key);
+
+        $this->assertSame([], $cookieJar->all());
+    }
+
     public function testCanClearAllCookies()
     {
         $cookies = $this->cookies();


### PR DESCRIPTION
This PR

* [x] asserts that a cookie can be cleared even if the key doesn't exist
* [x] removes a useless condition