### PR TITLE
Fix: Do not use isset

### DIFF
--- a/src/CookieJar.php
+++ b/src/CookieJar.php
@@ -35,10 +35,11 @@ class CookieJar
      */
     public function get($key)
     {
-        return isset($this->cookies[$key])
-            ? $this->cookies[$key]
-            : null
-            ;
+        if (!array_key_exists($key, $this->cookies)) {
+            return;
+        }
+
+        return $this->cookies[$key];
     }
 
     /**


### PR DESCRIPTION
This PR

* [x] uses `array_key_exists()` instead of `isset()`
* [x] removes a ternary statement