### PR TITLE
Remove support for PHP 5.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,6 @@ env:
 
 matrix:
   include:
-    - php: 5.5
-      env: WITH_CS=true
     - php: 5.6
       env: WITH_COVERAGE=true
 


### PR DESCRIPTION
:information_desk_person: This PR:

- [x] Removes support for PHP 5.5 from Travis.