### PR TITLE
Remove Travis support for PHP 5.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,6 @@ env:
 
 matrix:
   include:
-    - php: 5.5
-      env: WITH_CS=true
     - php: 5.6
       env: WITH_COVERAGE=true
 


### PR DESCRIPTION
As PHP 5.5's no longer officially supported, to me at least, it makes sense to not have it as an official Travis requirement.

This PR:

- [x] Removes support for it in `.travis.yml`