### PR TITLE
Enhancement: Provide MiddlewareInterface

### DIFF
--- a/src/MiddlewareInterface.php
+++ b/src/MiddlewareInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * Copyright (c) 2016 Refinery29, Inc.
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Refinery29\Piston;
+
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+
+interface MiddlewareInterface
+{
+    /**
+     * @param RequestInterface  $request
+     * @param ResponseInterface $response
+     * @param callable|null     $next
+     *
+     * @return ResponseInterface
+     */
+    public function __invoke(RequestInterface $request, ResponseInterface $response, callable $next = null);
+}


### PR DESCRIPTION
This PR

* [x] proposes a `MiddlewareInterface` to be used for future development

Replaces #188.

:information_desk_person: In order to easily allow `refinery29/piston` to use existing PSR-7 middleware, as well as to allow users of `refinery29/piston` to switch to a different framework, we should decide to use one of the available choices.

### Interface

A bunch of projects provide and/or use exactly the same interface, for example

* [`bitexpert/adroit`](https://github.com/bitExpert/adroit)
* [`madewithlove/glue`](https://github.com/madewithlove/glue)
* [`radar/adr`](https://github.com/radarphp/Radar.Adr)
* [`relay/relay`](https://github.com/relayphp/Relay.Relay/blob/1.x/src/MiddlewareInterface.php#L42)
* [`zendframework/zend-expressive`](https://github.com/zendframework/zend-expressive/blob/2db114f9c888e5ce06c808c44c47f70324be4d5c/src/Application.php#L138)
* [`zendframework/zend-stratigility`](https://github.com/zendframework/zend-stratigility/blob/master/src/MiddlewareInterface.php#L57)
* ...

### Existing Middleware using this interface

* [`akrabat/rka-ip-address-middleware`](https://github.com/akrabat/rka-ip-address-middleware)
* [`akrabat/rka-scheme-and-host-detection-middleware`](https://github.com/akrabat/rka-scheme-and-host-detection-middleware)
* [`bear/middleware`](https://github.com/bearsunday/BEAR.Middleware)
* [`hannesvdvreken/psr7-middlewares`](https://github.com/hannesvdvreken/psr7-middlewares)
* [`los/api-problem`](https://github.com/Lansoweb/api-problem)
* [`los/los-rate-limit`](https://github.com/Lansoweb/LosRateLimit)
* [`monii/monii-action-handler-psr7-middleware`](https://github.com/monii/monii-action-handler-psr7-middleware)
* [`monii/monii-nikic-fast-route-psr7-middleware`](https://github.com/monii/monii-nikic-fast-route-psr7-middleware)
* [`monii/monii-response-assertion-psr7-middleware`](https://github.com/monii/monii-response-assertion-psr7-middleware)
* [`mtymek/blast-base-url`](https://github.com/mtymek/blast-base-url)
* [`ocramius/psr7-session`](https://github.com/Ocramius/PSR7Session)
* [`oscarotero/psr7-middlewares`](https://github.com/oscarotero/psr7-middlewares)
* [`php-middleware/block-robots`](https://github.com/php-middleware/block-robots)
* [`php-middleware/http-authentication`](https://github.com/php-middleware/http-authentication)
* [`php-middleware/log-http-messages`](https://github.com/php-middleware/log-http-messages)
* [`php-middleware/maintenance`](https://github.com/php-middleware/maintenance)
* [`php-middleware/phpdebugbar`](https://github.com/php-middleware/phpdebugbar)
* [`php-middleware/request-id`](https://github.com/php-middleware/request-id)
* [`relay/middleware`](https://github.com/relayphp/Relay.Middleware)
* ...

For reference, see, for example: 

* https://akrabat.com/writing-psr-7-middleware/ 
* https://www.youtube.com/watch?v=MTzWlQo9sAk (https://speakerdeck.com/simensen/hello-psr-7-phpday-2015)
* http://weierophinney.github.io/2015-10-20-PSR-7-and-Middleware/#/
* https://www.youtube.com/watch?v=3AFR1BeiO2Q
* too many to list

/cc @alucic @carawarner @jingjingdong @kayladnls @rcatlin @settermjd @zcuric 