### PR TITLE
Enhancement: Rename all variables and function arguments to be camel-cased

### DIFF
--- a/src/Middleware/Request/Pagination/OffsetLimitPagination.php
+++ b/src/Middleware/Request/Pagination/OffsetLimitPagination.php
@@ -23,12 +23,12 @@ class OffsetLimitPagination implements StageInterface
     /**
      * @var int
      */
-    protected $default_offset = 0;
+    protected $defaultOffset = 0;
 
     /**
      * @var int
      */
-    protected $default_limit = 10;
+    protected $defaultLimit = 10;
 
     /**
      * @param Payload $payload
@@ -51,8 +51,8 @@ class OffsetLimitPagination implements StageInterface
             $this->ensureNotPreviouslyPaginated($request);
             $this->ensureGetOnlyRequest($request);
 
-            $offset = $offset ?: $this->default_offset;
-            $limit = $limit ?: $this->default_limit;
+            $offset = $offset ?: $this->defaultOffset;
+            $limit = $limit ?: $this->defaultLimit;
             $request->setOffsetLimit($offset, $limit);
         }
 

--- a/src/Request.php
+++ b/src/Request.php
@@ -129,13 +129,13 @@ class Request extends ServerRequest
     }
 
     /**
-     * @param array $included_resources
+     * @param array $includedResources
      *
      * @deprecated
      */
-    public function setIncludedResources(array $included_resources)
+    public function setIncludedResources(array $includedResources)
     {
-        $this->includedResources = $included_resources;
+        $this->includedResources = $includedResources;
     }
 
     /**
@@ -147,24 +147,24 @@ class Request extends ServerRequest
     }
 
     /**
-     * @param string $after_cursor
+     * @param string $afterCursor
      *
      * @deprecated
      */
-    public function setAfterCursor($after_cursor)
+    public function setAfterCursor($afterCursor)
     {
-        $this->afterCursor = $after_cursor;
+        $this->afterCursor = $afterCursor;
         $this->paginationType = self::CURSOR_PAGINATION;
     }
 
     /**
-     * @param string $before_cursor
+     * @param string $beforeCursor
      *
      * @deprecated
      */
-    public function setBeforeCursor($before_cursor)
+    public function setBeforeCursor($beforeCursor)
     {
-        $this->beforeCursor = $before_cursor;
+        $this->beforeCursor = $beforeCursor;
         $this->paginationType = self::CURSOR_PAGINATION;
     }
 


### PR DESCRIPTION
This PR

* [x] Updates any variable or function argument which uses [snake-casing](https://en.wikipedia.org/wiki/Snake_case) instead of [camel-casing](https://en.wikipedia.org/wiki/CamelCase). 

This isn't a big thing, but worthwhile for sakes of consistency.