### PR TITLE
Add in a getSorts method

### DIFF
--- a/src/Request.php
+++ b/src/Request.php
@@ -263,6 +263,14 @@ class Request extends ServerRequest
     }
 
     /**
+     * @return array
+     */
+    public function getSorts()
+    {
+        return $this->sorts;
+    }
+
+    /**
      * @param string $name
      *
      * @return bool

--- a/test/Unit/RequestTest.php
+++ b/test/Unit/RequestTest.php
@@ -289,6 +289,26 @@ class RequestTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($cookies, $request->getCookies());
     }
 
+    public function testGetSetSorts()
+    {
+        $faker = $this->getFaker();
+        $sorts = [
+            $faker->word => 'DESC',
+            $faker->word => 'ASC',
+            $faker->word => 'DESC',
+        ];
+
+        $request = new Request();
+
+        $request->setSorts($sorts);
+
+        $this->assertSame($sorts, $request->getSorts());
+
+        foreach (array_keys($sorts) as $sort) {
+            $this->assertTrue($request->hasSort($sort));
+        }
+    }
+
     /**
      * @return \PHPUnit_Framework_MockObject_MockObject|CookieJar
      */


### PR DESCRIPTION
## Summary
In order to support proper error reporting, we need access to the list of sorts that are provided.

This will allow us to maintain the order of multiple sorts as well