### PR TITLE
Bug: make requested fields array by default

### DIFF
--- a/src/Request.php
+++ b/src/Request.php
@@ -32,7 +32,7 @@ class Request extends ServerRequest
     /**
      * @var array
      */
-    protected $requestedFields;
+    protected $requestedFields = [];
 
     /**
      * @var array

--- a/test/Unit/RequestTest.php
+++ b/test/Unit/RequestTest.php
@@ -41,7 +41,6 @@ class RequestTest extends \PHPUnit_Framework_TestCase
         $request = new Request();
 
         $this->assertSame([], $request->getRequestedFields());
-
     }
 
     public function testWithRequestedFieldsClonesRequestAndSetsRequestedFields()

--- a/test/Unit/RequestTest.php
+++ b/test/Unit/RequestTest.php
@@ -36,6 +36,14 @@ class RequestTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($requestedFields, $request->getRequestedFields());
     }
 
+    public function testRequestedFieldsIsArrayByDefault()
+    {
+        $request = new Request();
+
+        $this->assertSame([], $request->getRequestedFields());
+
+    }
+
     public function testWithRequestedFieldsClonesRequestAndSetsRequestedFields()
     {
         $requestedFields = $this->getFaker()->words;


### PR DESCRIPTION
This PR

* [x] sets the default for requested fields to be an empty array so that `getRequestedFields` always returns an array, as advertised
