### PR TITLE
Allows includes query parameter on non-get requests

### DIFF
--- a/spec/Middleware/Request/IncludedResourceSpec.php
+++ b/spec/Middleware/Request/IncludedResourceSpec.php
@@ -9,7 +9,6 @@
 
 namespace spec\Refinery29\Piston\Middleware\Request;
 
-use League\Route\Http\Exception\BadRequestException;
 use PhpSpec\ObjectBehavior;
 use Refinery29\Piston\ApiResponse;
 use Refinery29\Piston\Middleware\Payload;
@@ -60,27 +59,5 @@ class IncludedResourceSpec extends ObjectBehavior
         $resources->shouldContain(['foo', 'bing']);
         $resources->shouldContain('bar');
         $resources->shouldContain('baz');
-    }
-
-    public function it_does_not_ensure_get_only_request_when_no_resources_included(
-        Piston $middleware
-    ) {
-        $request = (new Request())->withMethod('POST');
-
-        $result = $this->process(new Payload($middleware->getWrappedObject(),
-            $request, new ApiResponse()))->getRequest();
-
-        $result->shouldHaveType(Request::class);
-    }
-
-    public function it_ensures_get_only_request_when_resources_are_included(
-        Piston $middleware
-    ) {
-        $request = (new Request())->withMethod('POST')->withQueryParams(['include' => 'foo']);
-
-        $payload = new Payload($middleware->getWrappedObject(), $request,
-            new ApiResponse());
-
-        $this->shouldThrow(BadRequestException::class)->duringProcess($payload);
     }
 }

--- a/src/Middleware/Request/IncludedResource.php
+++ b/src/Middleware/Request/IncludedResource.php
@@ -10,14 +10,11 @@
 namespace Refinery29\Piston\Middleware\Request;
 
 use League\Pipeline\StageInterface;
-use Refinery29\Piston\Middleware\GetOnlyStage;
 use Refinery29\Piston\Middleware\Payload;
 use Refinery29\Piston\Request;
 
 class IncludedResource implements StageInterface
 {
-    use GetOnlyStage;
-
     /**
      * @param Payload $payload
      *
@@ -33,8 +30,6 @@ class IncludedResource implements StageInterface
         if (!isset($request->getQueryParams()['include'])) {
             return $payload;
         }
-
-        $this->ensureGetOnlyRequest($request);
 
         $include = explode(',', $request->getQueryParams()['include']);
 


### PR DESCRIPTION
This PR

* [x] Removes ensuring the request is `GET` during the `IncludedResource` stage 
* [x] Removes tests asserting only `GET` requests can have the `includes` query parameter 


❓ The `includes` query paramter is used during transformation/serialization and can be used when performing UPDATE (`PUT`, `PATCH`, `POST)` methods to ensure certain resources are included in the response.