### PR TITLE
Fix: Specify phony targets in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+.PHONY: composer coverage cs humbug spec test unit
+
 it: cs test
 
 composer:


### PR DESCRIPTION
This PR

* [x] specifies phony targets in `Makefile`

💁‍♂️ For reference, see https://www.gnu.org/software/make/manual/html_node/Phony-Targets.html:

>### 4.6 Phony Targets
>
>A phony target is one that is not really the name of a file; rather it is just a name for a recipe to be executed when you make an explicit request. There are two reasons to use a phony target: to avoid a conflict with a file of the same name, and to improve performance.