### PR TITLE
Fix: Keep composer updated and validate composer.json

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,8 @@
 it: cs test
 
 composer:
+	composer self-update
+	composer validate
 	composer install
 
 coverage: composer


### PR DESCRIPTION
This PR

* [x] keeps `composer` itself updated and validates `composer.json` and `composer.lock` in `composer` target of `Makefile`
