### PR TITLE
Fix: Add PHP 7.0 to Travis build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,10 @@ matrix:
       env: WITH_LOWEST=true
     - php: 5.6
       env: WITH_HIGHEST=true WITH_CS=true WITH_COVERAGE=true
+    - php: 7.0
+      env: WITH_LOWEST=true
+    - php: 7.0
+      env: WITH_HIGHEST=true
 
 cache:
   directories:


### PR DESCRIPTION
This PR

* [x] adds PHP 7.0 to the Travis build matrix