### PR TITLE
Fix: Add PHP 7.1 to Travis build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,10 @@ matrix:
       env: WITH_LOWEST=true
     - php: 7.0
       env: WITH_HIGHEST=true
+    - php: 7.1
+      env: WITH_LOWEST=true
+    - php: 7.1
+      env: WITH_HIGHEST=true
 
 cache:
   directories:


### PR DESCRIPTION
This PR

* [x] adds PHP 7.1 to the Travis build matrix

Follows #226.