### PR TITLE
Enhancement: Update refinery29/php-cs-fixer-config

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -7,7 +7,7 @@ For the full copyright and license information, please view
 the LICENSE file that was distributed with this source code.
 EOF;
 
-$config = new Refinery29\CS\Config\Refinery29($header);
+$config = new Refinery29\CS\Config\Php56($header);
 $config->getFinder()->in(__DIR__);
 
 $cacheDir = getenv('TRAVIS') ? getenv('HOME') . '/.php-cs-fixer' : __DIR__;

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
     "phpspec/nyan-formatters": "^2.0.0",
     "phpspec/phpspec": "^3.4.0",
     "phpunit/phpunit": "^5.2.8",
-    "refinery29/php-cs-fixer-config": "0.4.18",
+    "refinery29/php-cs-fixer-config": "0.10.1",
     "refinery29/test-util": "0.3.0"
   },
   "autoload": {

--- a/spec/Middleware/Request/Pagination/OffsetLimitPaginationSpec.php
+++ b/spec/Middleware/Request/Pagination/OffsetLimitPaginationSpec.php
@@ -114,7 +114,7 @@ class OffsetLimitPaginationSpec extends ObjectBehavior
     public function it_will_not_allow_previously_paginated_requests(Piston $piston)
     {
         $request = RequestFactory::fromGlobals()->withQueryParams(['limit' => 123]);
-        $request->setBeforeCursor(rand());
+        $request->setBeforeCursor(\rand());
 
         $this->shouldThrow(BadRequestException::class)->duringprocess($this->getPayload($request, $piston));
     }

--- a/spec/Middleware/Request/Pagination/PagedPaginationSpec.php
+++ b/spec/Middleware/Request/Pagination/PagedPaginationSpec.php
@@ -74,7 +74,7 @@ class PagedPaginationSpec extends ObjectBehavior
     public function it_will_not_allow_previously_paginated_requests(Piston $piston)
     {
         $request = RequestFactory::fromGlobals()->withQueryParams(['page' => 1]);
-        $request->setBeforeCursor(rand());
+        $request->setBeforeCursor(\rand());
 
         $this->shouldThrow(BadRequestException::class)->duringprocess($this->getPayload($request, $piston));
     }

--- a/spec/Middleware/Request/SortsSpec.php
+++ b/spec/Middleware/Request/SortsSpec.php
@@ -31,7 +31,7 @@ class SortsSpec extends ObjectBehavior
     {
         /** @var Request $request */
         $request = (new Request())->withQueryParams([
-            'sort' => implode(',', [
+            'sort' => \implode(',', [
                 '-created',
                 'title',
             ]),

--- a/src/ApiResponse.php
+++ b/src/ApiResponse.php
@@ -75,7 +75,7 @@ class ApiResponse extends DiactorosResponse implements CompiledResponse
     public function setCustomResult(CustomResult $customResult)
     {
         $this->checksForCustomObject();
-        if (count($this->responseBody->getMembers()) > 0) {
+        if (\count($this->responseBody->getMembers()) > 0) {
             throw new \Exception(self::ERROR_CANNOT_USE_CUSTOM_AND_OTHER_RESOURCES);
         }
         $this->responseBody->addMember($customResult->getSerializer());

--- a/src/CookieJar.php
+++ b/src/CookieJar.php
@@ -23,7 +23,7 @@ class CookieJar
      */
     public function __construct(array $cookies = [])
     {
-        Assertion::allString(array_keys($cookies), 'CookieJar must be instantiated with an associative array');
+        Assertion::allString(\array_keys($cookies), 'CookieJar must be instantiated with an associative array');
 
         $this->cookies = $cookies;
     }
@@ -37,7 +37,7 @@ class CookieJar
     {
         Assertion::string($key);
 
-        if (!array_key_exists($key, $this->cookies)) {
+        if (!\array_key_exists($key, $this->cookies)) {
             return;
         }
 

--- a/src/Middleware/Request/IncludedResource.php
+++ b/src/Middleware/Request/IncludedResource.php
@@ -31,12 +31,12 @@ class IncludedResource implements StageInterface
             return $payload;
         }
 
-        $include = explode(',', $request->getQueryParams()['include']);
+        $include = \explode(',', $request->getQueryParams()['include']);
 
         if (!empty($include)) {
             foreach ((array) $include as $k => $resource) {
-                if (strpos($resource, '.') !== false) {
-                    $resource = explode('.', $resource);
+                if (\strpos($resource, '.') !== false) {
+                    $resource = \explode('.', $resource);
                     $include[$k] = $resource;
                 }
             }

--- a/src/Middleware/Request/Pagination/OffsetLimitPagination.php
+++ b/src/Middleware/Request/Pagination/OffsetLimitPagination.php
@@ -72,7 +72,7 @@ class OffsetLimitPagination implements StageInterface
      */
     private function coerceToInteger($param, $param_name)
     {
-        if (is_numeric($param)) {
+        if (\is_numeric($param)) {
             $integer_value = (int) $param;
 
             if ($integer_value == (float) $param) {

--- a/src/Middleware/Request/Pagination/PagedPagination.php
+++ b/src/Middleware/Request/Pagination/PagedPagination.php
@@ -79,7 +79,7 @@ class PagedPagination implements StageInterface
      */
     private function coerceToInteger($param, $param_name)
     {
-        if (is_numeric($param)) {
+        if (\is_numeric($param)) {
             $integer_value = (int) $param;
 
             if ($integer_value == (float) $param) {

--- a/src/Middleware/Request/RequestPipeline.php
+++ b/src/Middleware/Request/RequestPipeline.php
@@ -34,7 +34,7 @@ class RequestPipeline implements StageInterface
      */
     public function __construct(PipelineBuilder $builder = null)
     {
-        $this->builder = $builder ?:  new PipelineBuilder();
+        $this->builder = $builder ?: new PipelineBuilder();
     }
 
     /**

--- a/src/Middleware/Request/RequestedFields.php
+++ b/src/Middleware/Request/RequestedFields.php
@@ -36,7 +36,7 @@ class RequestedFields implements StageInterface
 
         if ($fields) {
             $this->ensureGetOnlyRequest($request);
-            $fields = explode(',', $fields);
+            $fields = \explode(',', $fields);
         }
 
         if (!empty($fields)) {

--- a/src/Middleware/Request/Sorts.php
+++ b/src/Middleware/Request/Sorts.php
@@ -40,7 +40,7 @@ class Sorts implements StageInterface
 
         $this->ensureGetOnlyRequest($request);
 
-        $providedSorts = explode(',', $request->getQueryParams()['sort']);
+        $providedSorts = \explode(',', $request->getQueryParams()['sort']);
 
         if (empty($providedSorts)) {
             return $payload;
@@ -49,12 +49,12 @@ class Sorts implements StageInterface
         $sorts = [];
 
         foreach ($providedSorts as $sort) {
-            if (strlen($sort) <= 0 || $sort === '-') {
+            if (\strlen($sort) <= 0 || $sort === '-') {
                 throw new BadRequestException('Sort parameter cannot be empty.');
             }
 
             if ($sort[0] === '-') {
-                $sorts[substr($sort, 1)] = self::SORT_DESCENDING;
+                $sorts[\substr($sort, 1)] = self::SORT_DESCENDING;
                 continue;
             }
 

--- a/src/Piston.php
+++ b/src/Piston.php
@@ -97,7 +97,7 @@ class Piston extends RouteCollection implements Middleware\HasMiddleware
      */
     public function map($method, $path, $handler)
     {
-        $path = sprintf('/%s', ltrim($path, '/'));
+        $path = \sprintf('/%s', \ltrim($path, '/'));
 
         $route = (new Route())
             ->setMethods((array) $method)

--- a/src/Request.php
+++ b/src/Request.php
@@ -293,7 +293,7 @@ class Request extends ServerRequest
      */
     public function hasSort($name)
     {
-        return array_key_exists($name, $this->sorts);
+        return \array_key_exists($name, $this->sorts);
     }
 
     /**

--- a/src/Router/MiddlewareStrategy.php
+++ b/src/Router/MiddlewareStrategy.php
@@ -39,7 +39,7 @@ class MiddlewareStrategy extends RequestResponseStrategy implements StrategyInte
             ->handlePayload(new Payload($route, $this->request, $this->response))
             ->getResponse();
 
-        return call_user_func_array($controller,
+        return \call_user_func_array($controller,
             [$this->request, $this->response, $vars]
         );
     }

--- a/test/Unit/CookieJarTest.php
+++ b/test/Unit/CookieJarTest.php
@@ -133,7 +133,7 @@ class CookieJarTest extends \PHPUnit_Framework_TestCase
     {
         $cookies = $this->cookies();
 
-        $key = array_rand($cookies, 1);
+        $key = \array_rand($cookies, 1);
 
         $cookieJar = new CookieJar($cookies);
 
@@ -192,7 +192,7 @@ class CookieJarTest extends \PHPUnit_Framework_TestCase
 
         $count = $count ?: $faker->numberBetween(5, 15);
 
-        return array_combine(
+        return \array_combine(
             $faker->words($count),
             $faker->words($count)
         );

--- a/test/Unit/RequestTest.php
+++ b/test/Unit/RequestTest.php
@@ -246,7 +246,7 @@ class RequestTest extends \PHPUnit_Framework_TestCase
             ->expects($this->once())
             ->method('get')
             ->willReturnCallback(function ($key) use ($cookies) {
-                if (array_key_exists($key, $cookies)) {
+                if (\array_key_exists($key, $cookies)) {
                     return $cookies[$key];
                 }
             });
@@ -317,7 +317,7 @@ class RequestTest extends \PHPUnit_Framework_TestCase
 
         $this->assertSame($sorts, $request->getSorts());
 
-        foreach (array_keys($sorts) as $sort) {
+        foreach (\array_keys($sorts) as $sort) {
             $this->assertTrue($request->hasSort($sort));
         }
     }


### PR DESCRIPTION
This PR

* [x] updates `refinery29/php-cs-fixer-config`
* [x] uses `Refinery29\CS\Config\Php56` instead of removed `Refinery29\CS\Config\Refinery29`
* [x] runs `make cs`

💁‍♂️ For reference, see https://github.com/refinery29/php-cs-fixer-config/compare/0.4.18...0.10.1.