### PR TITLE
Fix: Raise minimum stability to default levels

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -53,8 +53,6 @@
       "spec\\Refinery29\\Piston\\": "spec"
     }
   },
-  "minimum-stability": "dev",
-  "prefer-stable": true,
   "config": {
     "bin-dir": "bin",
     "preferred-install": "dist",


### PR DESCRIPTION
This PR

* [x] raises minimum stability to default levels (stable) in `composer.json`

Follows #229.

💁‍♂️ We needed this previously only to pull in an unstable version of `friendsofphp/php-cs-fixer`.