### PR TITLE
Fix: Disable and enable xdebug only when needed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,8 @@ cache:
     - $HOME/.php-cs-fixer
 
 before_install:
-  - if [[ "$WITH_COVERAGE" != "true" ]]; then phpenv config-rm xdebug.ini; fi
+  - source .travis/xdebug.sh
+  - xdebug-disable
   - composer self-update
   - composer validate
   - composer config github-oauth.github.com $GITHUB_TOKEN
@@ -42,7 +43,9 @@ before_script:
 
 script:
   - vendor/bin/phpspec run --format=dot --config=phpspec.yml
+  - if [[ "$WITH_COVERAGE" == "true" ]]; then xdebug-enable; fi
   - if [[ "$WITH_COVERAGE" == "true" ]]; then vendor/bin/phpunit --configuration=test/Unit/phpunit.xml --coverage-clover=build/logs/clover.xml; else vendor/bin/phpunit --configuration=test/Unit/phpunit.xml; fi
+  - if [[ "$WITH_COVERAGE" == "true" ]]; then xdebug-disable; fi
   - if [[ "$WITH_CS" == "true" ]]; then vendor/bin/php-cs-fixer fix --config=.php_cs --verbose --diff --dry-run; fi
 
 after_success:

--- a/.travis/xdebug.sh
+++ b/.travis/xdebug.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+# The problem is that we do not want to remove the configuration file, just disable it for a few tasks, then enable it
+#
+# For reference, see
+#
+# - https://docs.travis-ci.com/user/languages/php#Disabling-preinstalled-PHP-extensions
+# - https://docs.travis-ci.com/user/languages/php#Custom-PHP-configuration
+
+config="/home/travis/.phpenv/versions/$(phpenv version-name)/etc/conf.d/xdebug.ini"
+
+function xdebug-disable() {
+    if [[ -f $config ]]; then
+        mv $config "$config.bak"
+    fi
+}
+
+function xdebug-enable() {
+    if [[ -f "$config.bak" ]]; then
+        mv "$config.bak" $config
+    fi
+}


### PR DESCRIPTION
This PR

* [x] disables xdebug as early as possible and enables it only for steps where it is needed