### PR TITLE
Fix: Specify path to phpunit.xsd relative to phpunit.xml

### DIFF
--- a/test/Unit/phpunit.xml
+++ b/test/Unit/phpunit.xml
@@ -1,6 +1,6 @@
 <phpunit
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.8/phpunit.xsd"
+    xsi:noNamespaceSchemaLocation="../../vendor/phpunit/phpunit/phpunit.xsd"
     beStrictAboutChangesToGlobalState="true"
     beStrictAboutOutputDuringTests="true"
     beStrictAboutTestsThatDoNotTestAnything="true"


### PR DESCRIPTION
This PR

* [x] specifies the path to `phpunit.xsd` relative to `phpunit.xml`

💁‍♂️ This way it will always be relevant, regardless of the currently installed version of `phpunit/phpunit`.