### PR TITLE
Enhancement: Update refinery29/test-util

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,13 +34,12 @@
   },
   "require-dev": {
     "codeclimate/php-test-reporter": "0.4.4",
-    "fzaninotto/faker": "^1.5.0",
     "humbug/humbug": "^1.0.0-alpha1",
     "phpspec/nyan-formatters": "^2.0.0",
     "phpspec/phpspec": "^3.4.0",
     "phpunit/phpunit": "^5.2.8",
     "refinery29/php-cs-fixer-config": "0.10.1",
-    "refinery29/test-util": "0.3.0"
+    "refinery29/test-util": "0.11.4"
   },
   "autoload": {
     "psr-4": {

--- a/test/Unit/CookieJarTest.php
+++ b/test/Unit/CookieJarTest.php
@@ -11,11 +11,11 @@ namespace Refinery29\Piston\Test\Unit;
 
 use InvalidArgumentException;
 use Refinery29\Piston\CookieJar;
-use Refinery29\Test\Util\Faker\GeneratorTrait;
+use Refinery29\Test\Util\TestHelper;
 
 class CookieJarTest extends \PHPUnit_Framework_TestCase
 {
-    use GeneratorTrait;
+    use TestHelper;
 
     public function testConstructorRejectsInvalidCookies()
     {

--- a/test/Unit/RequestTest.php
+++ b/test/Unit/RequestTest.php
@@ -12,11 +12,11 @@ namespace Refinery29\Piston\Test\Unit;
 use Refinery29\Piston\CookieJar;
 use Refinery29\Piston\Middleware\Request\Sorts;
 use Refinery29\Piston\Request;
-use Refinery29\Test\Util\Faker\GeneratorTrait;
+use Refinery29\Test\Util\TestHelper;
 
 class RequestTest extends \PHPUnit_Framework_TestCase
 {
-    use GeneratorTrait;
+    use TestHelper;
 
     public function testDefaults()
     {


### PR DESCRIPTION
This PR

* [x] updates `refinery29/test-util`
* [x] uses the `TestHelper` trait instead of removed `GeneratorTrait`

💁‍♂️ For reference, see https://github.com/refinery29/test-util/compare/0.3.0...0.11.4.