### PR TITLE
Fix: Use default location for binaries installed with composer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,12 +41,12 @@ before_script:
   - mkdir -p build/logs
 
 script:
-  - bin/phpspec run --format=dot --config=phpspec.yml
-  - if [[ "$WITH_COVERAGE" == "true" ]]; then bin/phpunit --configuration=test/Unit/phpunit.xml --coverage-clover=build/logs/clover.xml; else bin/phpunit --configuration=test/Unit/phpunit.xml; fi
-  - if [[ "$WITH_CS" == "true" ]]; then bin/php-cs-fixer fix --config=.php_cs --verbose --diff --dry-run; fi
+  - vendor/bin/phpspec run --format=dot --config=phpspec.yml
+  - if [[ "$WITH_COVERAGE" == "true" ]]; then vendor/bin/phpunit --configuration=test/Unit/phpunit.xml --coverage-clover=build/logs/clover.xml; else vendor/bin/phpunit --configuration=test/Unit/phpunit.xml; fi
+  - if [[ "$WITH_CS" == "true" ]]; then vendor/bin/php-cs-fixer fix --config=.php_cs --verbose --diff --dry-run; fi
 
 after_success:
-  - if [[ "$WITH_COVERAGE" == "true" ]]; then bin/test-reporter --coverage-report=build/logs/clover.xml; fi
+  - if [[ "$WITH_COVERAGE" == "true" ]]; then vendor/bin/test-reporter --coverage-report=build/logs/clover.xml; fi
 
 notifications:
   email: false

--- a/Makefile
+++ b/Makefile
@@ -9,18 +9,18 @@ composer:
 	composer install
 
 coverage: composer
-	bin/phpunit --configuration test/Unit/phpunit.xml --coverage-text
+	vendor/bin/phpunit --configuration test/Unit/phpunit.xml --coverage-text
 
 cs: composer
-	bin/php-cs-fixer fix --config=.php_cs --verbose --diff
+	vendor/bin/php-cs-fixer fix --config=.php_cs --verbose --diff
 
 humbug:
-	bin/humbug
+	vendor/bin/humbug
 
 test: composer
-	bin/phpspec run --config phpspec.yml
-	bin/phpunit --configuration=test/Unit/phpunit.xml
+	vendor/bin/phpspec run --config phpspec.yml
+	vendor/bin/phpunit --configuration=test/Unit/phpunit.xml
 	composer update --prefer-lowest
-	bin/phpspec run --config phpspec.yml
-	bin/phpunit --configuration=test/Unit/phpunit.xml
+	vendor/bin/phpspec run --config phpspec.yml
+	vendor/bin/phpunit --configuration=test/Unit/phpunit.xml
 

--- a/composer.json
+++ b/composer.json
@@ -56,7 +56,6 @@
   "minimum-stability": "dev",
   "prefer-stable": true,
   "config": {
-    "bin-dir": "bin",
     "preferred-install": "dist",
     "sort-packages": true
   }


### PR DESCRIPTION
This PR

* [x] uses the default location for binaries installed with `composer`