### PR TITLE
Fix: Add missing parameter to method signature

### DIFF
--- a/spec/Stub/FooController.php
+++ b/spec/Stub/FooController.php
@@ -21,7 +21,7 @@ class FooController
         return $resp;
     }
 
-    public function test(Request $req, ApiResponse $response)
+    public function test(Request $req, ApiResponse $response, array $vars)
     {
         $response->setResult(ResourceFactory::result(['something' => 'yolo']));
 


### PR DESCRIPTION
This PR

* [x] adds a missing parameter to the signature of a controller action