### PR TITLE
Update Pipeline On Piston to Fix array_reduce() Bug

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
   "require": {
     "php": "^5.6 || ^7.0",
     "beberlei/assert": "^2.5.1",
-    "league/pipeline": "0.1.0",
+    "league/pipeline": "0.3.0",
     "league/route": "^2.0.0",
     "refinery29/api-output": "0.3.4",
     "zendframework/zend-diactoros": "^1.3.3"


### PR DESCRIPTION
## This Pr:
Upgrade league/pipelin to 0.3.0 to fix a bug with array_reduce() that the league/pipeline made.

## Our NewRelic:
https://rpm.newrelic.com/accounts/60268/applications/12511608/traced_errors/b1f4e05b-96ff-11e7-848b-0242ac11000a_831_2807/similar_errors?original_error_id=29074c54-67f4-11e7-a209-0242ac110010_0_2059

stacktrace shows league/pipeline is the issue and a member in that repo fixed the problem, this is a known problem within thephpleague/pipeline github page;

## League/PipeLine Github Page of the error they fixed:
`**removed**`

## Jira Ticket: 
https://refinery29.atlassian.net/browse/ZP-1684

## QA:
.... pending
